### PR TITLE
Fix double escape in CSS

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -123,7 +123,7 @@ Open app/assets/stylesheets/application.css and add to the bottom:
 {% highlight css %}
 #logo { 
     font-size: 20px;
-    font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
     float: left;
     padding: 10px;
 }


### PR DESCRIPTION
The font declaration example in [app tutorial](http://guides.railsgirls.com/app/#step_3_design) renders quotes as HTML entities. This fixes the double escape.
