### PR TITLE
Fix error in commenting instructions.

### DIFF
--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -101,7 +101,7 @@ In app/controllers/ideas_controller.rb add to show action after the row
 
 this
 {% highlight ruby %}
-@comment = @idea.comments.new
+@comment = @idea.comments.build
 {% endhighlight %}
 
 Open comments/_form.html and after


### PR DESCRIPTION
The comments instructions had a typo. This fixes it.
