### PR TITLE
Remove CSS for nonexistent ids and classes

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -122,18 +122,10 @@ and before `</body>` add:
 Open app/assets/stylesheets/application.css and add to the bottom:
 
 {% highlight css %}
-#logo { 
-    font-size: 20px;
-    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-    float: left;
-    padding: 10px;
-}
 body { padding-top: 100px; }
 footer { margin-top: 100px; }
 table, td, th { vertical-align: middle !important; border: none !important; }
 th { border-bottom: 1px solid #DDD !important; }
-td.picture { width: 140px; }
-td.picture img { width: 140px; }
 {% endhighlight %}
 
 **Coach:** Talk a little about CSS and layouts.


### PR DESCRIPTION
All three girls I coached yesterday were modifying the CSS after they finished the guide and then wondered why the font size in the header didn't change.

I also think replacing the entire file with the provided CSS would be better as it would get rid of the asset pipeline statements. The generated `scaffolds.css.scss` overlaps with Twitter Bootstrap and causes issues when editing `application.css` for basic things like the background color of the body.
