### PR TITLE
changing recommended editor to sublime text

### DIFF
--- a/_posts/2012-04-18-install.markdown
+++ b/_posts/2012-04-18-install.markdown
@@ -22,9 +22,9 @@ Follow the instructions for your operating system. If you hit into any problems,
 
 Download [RailsInstaller](https://github.com/downloads/railsinstaller/railsinstaller-nix/RailsInstaller-1.0.3-osx-10.7.app.tgz). Double click the downloaded file and it will unpack it into the current directory. Double click the the newly unpacked 'RailsInstaller-1.0.3-osx-10.7.app' and follow the instructions. It will open a README file with 'Rails Installer OS X' at the top. Please ignore the instructions in this file.
 
-You also need a text editor to edit code files. For the workshop we recommend the free code editor Komodo Edit.
+You also need a text editor to edit code files. For the workshop we recommend the text editor Sublime Text.
 
-* [Download the Komodo Edit and install it.](http://www.activestate.com/komodo-edit/downloads)
+* [Download Sublime Text and install it](http://www.sublimetext.com/2)
 
 <hr />
 
@@ -68,9 +68,9 @@ bash < <(curl -s https://raw.github.com/railsgirls/installation-scripts/master/r
 
 Now if everything went right, you should have a working Ruby on Rails programming setup. Congrats!
 
-**Final step.** Install a text editor to edit code files. For the workshop we recommend the free code editor Komodo Edit.
+**Final step.** Install a text editor to edit code files. For the workshop we recommend the text editor Sublime Text.
 
-* [Download Komodo Edit and install it.](http://www.activestate.com/komodo-edit/downloads)
+* [Download Sublime Text and install it](http://www.sublimetext.com/2)
 
 <hr />
 
@@ -78,9 +78,9 @@ Now if everything went right, you should have a working Ruby on Rails programmin
 
 Download [RailsInstaller](http://rubyforge.org/frs/download.php/75346/railsinstaller-2.0.0.exe) and run it. Click through the installer using the default options.
 
-You also need a text editor to edit code files. For the workshop we recommend the free code editor Komodo Edit.
+You also need a text editor to edit code files. For the workshop we recommend the text editor Sublime Text.
 
-* [Download the Komodo Edit and install it.](http://www.activestate.com/komodo-edit/downloads)
+* [Download Sublime Text and install it](http://www.sublimetext.com/2)
 
 Now you should have a working Ruby on Rails programming setup. Congrats!
 
@@ -94,6 +94,6 @@ To install Ruby on Rails development environment you just need to copy and paste
 bash < <(curl -s https://raw.github.com/railsgirls/installation-scripts/master/rails-install-ubuntu.sh)
 {% endhighlight %}
 
-You also need a text editor to edit code files. For the workshop we recommend the free code editor Komodo Edit.
+You also need a text editor to edit code files. For the workshop we recommend the text editor Sublime Text.
 
-* [Download Komodo Edit and install it.](http://www.activestate.com/komodo-edit/downloads)
+* [Download Sublime Text and install it](http://www.sublimetext.com/2)


### PR DESCRIPTION
As discussed in Issue #24 I prepared a pull request to change the recommended text editor to Sublime Text.

I also removed the word 'code editor' as the editor is otherwise always referred to as 'text editor'. It sounds a bit repetitive now but I thought it might lead to less confusion. Feel free to change it again if you don't like it.
