### PR TITLE
Updated Windows installation package version number

### DIFF
--- a/_posts/2012-04-18-install.markdown
+++ b/_posts/2012-04-18-install.markdown
@@ -46,7 +46,9 @@ Now you should have a working Ruby on Rails programming setup. Congrats!
 
 ## Setup for Windows
 
-Download [RailsInstaller](http://rubyforge.org/frs/download.php/75346/railsinstaller-2.0.0.exe) and run it. Click through the installer using the default options.
+Download [RailsInstaller](http://rubyforge.org/frs/download.php/75894/railsinstaller-2.1.0.exe) and run it. Click through the installer using the default options.
+
+Installation of Git and SSH-keys is required if you want to [put your app online with Heroku](/heroku).
 
 **Final step.** You also need a text editor to edit code files. For the workshop we recommend the text editor Sublime Text.
 


### PR DESCRIPTION
From Rails Girls Turku 12.-13.10.2012:

We noticed that version 2.0.0 had Gem-file problems on most of the Windows machines. At least Windows 7 and Windows Vista were affected. We tried a newer version 2.1.0 from http://railsinstaller.org/ which worked like a charm.

Maybe someone could confirm if virgin Windows XP is working with the new version? I feel comfortable about the version update because XP is 11 years old OS that doesn't have a mainstream support by Microsoft anymore.
