### PR TITLE
Corrected Anchor closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: Guides
     <a href="http://humancoders.github.com/railspremierspas/">Guides in French</a><br/>
     <a href="http://github.com/rgcn/rgcn.github.com">Guides in Chinese</a><br/>
     <a href="http://rgua.github.com">Guides in Russian</a><br/>
-<a href="http://www.maujor.com/railsgirlsguide/">Guides in Brazilian-Portuguese/a><br/>
+<a href="http://www.maujor.com/railsgirlsguide/">Guides in Brazilian-Portuguese</a><br/>
 
         
     </p>


### PR DESCRIPTION
Anchor tag was not properly closed, so anchor text for Guides in Brazilian-Portuguese appeared incorrectly on the screen as: Guides in Brazilian-Portuguese/a>
