### PR TITLE
Removed unnecessary config options

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,2 @@
-destination: ./_site
-auto:        false
-lsi:         false
-server_port: 4000
 pygments:    true
-markdown:    maruku
 permalink:   pretty
-maruku:
-  use_tex:    false
-  use_divs:   false
-  png_dir:    images/latex
-  png_url:    /images/latex


### PR DESCRIPTION
Ones that match the jekyll defaults don't need to be there, simplifies the config quite a lot.
@gissues:{"order":24.999999999999993,"status":"backlog"}
