### PR TITLE
remove old rails syntax

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -196,18 +196,6 @@ to
 <%= f.file_field :picture %>
 {% endhighlight %}
 
-and
-
-{% highlight erb %}
-<%= form_for(@idea) do |f| %>
-{% endhighlight %}
-
-to
-
-{% highlight erb %}
-<%= form_for(@idea, :html => { :multipart => true }) do |f| %>
-{% endhighlight %}
-
 When you upload a picture it doesn't look nice because it only shows a path to the file, so let's fix that.
 
 Open `app/views/ideas/show.html.erb` and change


### PR DESCRIPTION
latest Rails(3.2+) automatically generates multipart form when includes a file_fields.
