### PR TITLE
Fix "rails server" command on windows

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -43,8 +43,6 @@ First, let's open a terminal:
 
 Next, type these commands in the terminal:
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
 mkdir projects
 cd projects
@@ -52,18 +50,6 @@ rails new railsgirls
 cd railsgirls
 rails server
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-mkdir projects
-cd projects
-rails new railsgirls
-cd railsgirls
-rails server
-{% endhighlight %}
-  </div>
-</div>
 
 Open [http://localhost:3000](http://localhost:3000) in your browser. You should see "Welcome aboard" page, which means that the generation of your new app worked correctly.
 
@@ -78,23 +64,11 @@ We're going to use Rails' scaffold functionality to generate a starting point th
 
 **Coach:** What is Rails scaffolding? (Explain the command, the model name and related database table, naming conventions, attributes and types, etc.) What are migrations and why do you need them?
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
 rails generate scaffold idea name:string description:text picture:string
 rake db:migrate
 rails server
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-rails generate scaffold idea name:string description:text picture:string
-rake db:migrate
-rails server
-{% endhighlight %}
-  </div>
-</div>
 
 Open [http://localhost:3000/ideas](http://localhost:3000/ideas) in your browser. Click around and test what you got by running these few command-line commands.
 


### PR DESCRIPTION
Hello!
I fixed some commands on Windows in "Rails Girls App Tutorial"(http://guides.railsgirls.com/app/ ) with the first commit.
Then, they are the same as ones on the other environments, so I unified each commands with the second commit.

I checked commands on Windows in the tutorial page with this environments:

<pre>
OS: Windows7 (64bit)

C:\Users\yoiz\Desktop\rails-test\demo>ruby -v
ruby 1.9.3p392 (2013-02-22) [i386-mingw32]

C:\Users\yoiz\Desktop\rails-test\demo>gem -v
1.8.24

C:\Users\yoiz\Desktop\rails-test\demo>rails -v
Rails 3.2.13
</pre>


Thanks.
