### PR TITLE
Removing ruby script\rails server

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -43,8 +43,6 @@ First, let's open a terminal:
 
 Next, type these commands in the terminal:
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
 mkdir projects
 cd projects
@@ -52,22 +50,10 @@ rails new railsgirls
 cd railsgirls
 rails server
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-mkdir projects
-cd projects
-rails new railsgirls
-cd railsgirls
-ruby script\rails server
-{% endhighlight %}
-  </div>
-</div>
 
 Open [http://localhost:3000](http://localhost:3000) in your browser. You should see "Welcome aboard" page, which means that the generation of your new app worked correctly.
 
-Hit `CTRL-C` in the terminal to quit the server.
+Hit `CTRL-C` on Mac or `CTRL-BREAK` on Windows in the terminal to quit the server.
 
 **Coach:** Explain what each command does. What was generated? What does the server do?
 
@@ -78,27 +64,15 @@ We're going to use Rails' scaffold functionality to generate a starting point th
 
 **Coach:** What is Rails scaffolding? (Explain the command, the model name and related database table, naming conventions, attributes and types, etc.) What are migrations and why do you need them?
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
 rails generate scaffold idea name:string description:text picture:string
 rake db:migrate
 rails server
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-rails generate scaffold idea name:string description:text picture:string
-rake db:migrate
-ruby script\rails server
-{% endhighlight %}
-  </div>
-</div>
 
 Open [http://localhost:3000/ideas](http://localhost:3000/ideas) in your browser. Click around and test what you got by running these few command-line commands.
 
-Hit `CTRL-C` to quit the server again when you've clicked around a little.
+Hit `CTRL-C` on Mac or `CTRL-BREAK` on Windows to quit the server again when you've clicked around a little.
 
 
 ## *3.*Design


### PR DESCRIPTION
This is an offshoot of request #67. I believe (but I may not be in the majority) that for the sake of clarity that we remove the option to change OS which changes the line to start the rails server. 

![screen shot 2013-06-13 at 11 21 17 am](https://f.cloud.github.com/assets/2406167/649470/5750fe7e-d445-11e2-9342-2a9a094f8c9a.png)

We should try not to propagate the use of ruby script/[ARGS] since rails [ARGS] was purposely created to unify all rails commands into the same file. Also, if we are just trying to be brief, it seems like a  lot code just to change that one line, and the links are not necessarily obvious (hence #67 OP's confusion). Also, this is not a feature seen in the other language versions, all of which use rails server or rails s. If this is merged, we can go about adding Ctrl + break to the other languages as well.

So in this pull request I've removed the OS switching links, rails server is the only command given, and I added using ctrl + break for Windows users in both lines that instruct the user to quit the server.

![screen shot 2013-06-13 at 11 29 38 am](https://f.cloud.github.com/assets/2406167/649508/74fb3cb8-d446-11e2-9c28-78476a883431.png)
