### PR TITLE
Pin mini_magick to 3.5.0

### DIFF
--- a/_posts/2012-06-03-thumbnails.markdown
+++ b/_posts/2012-06-03-thumbnails.markdown
@@ -28,7 +28,7 @@ used before?
 Open `Gemfile` in the project and add
 
 {% highlight ruby %}
-gem 'mini_magick'
+gem 'mini_magick', '3.5.0'
 {% endhighlight %}
 
 under the line


### PR DESCRIPTION
Until probablycorey/mini_magick#4 is fixed, this won't work on Windows, so suggest the version that does work.
