### PR TITLE
Fixed typos and updated broken bootstrap.min.css link

### DIFF
--- a/_posts/2013-01-20-design.markdown
+++ b/_posts/2013-01-20-design.markdown
@@ -23,7 +23,7 @@ Open `app/views/layouts/application.html.erb` in your text editor and replace th
 with
 
 {% highlight html %}
-<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.no-icons.min.css">
+<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap.min.css">
 {% endhighlight %}
 
 and replace


### PR DESCRIPTION
I have fixed some typos/grammar and improved the language to make it read better in places.

The link to the Bootstrap stylesheet was outdated and no longer working, so I updated it to http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap.min.css (the most recent version while Bootstrap 3 is still a work in progress).

Thanks :)
