### PR TITLE
Fix path to `rails`

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -60,7 +60,7 @@ mkdir projects
 cd projects
 rails new railsgirls
 cd railsgirls
-ruby script\rails server
+ruby bin\rails server
 {% endhighlight %}
   </div>
 </div>
@@ -91,7 +91,7 @@ rails server
 {% highlight sh %}
 rails generate scaffold idea name:string description:text picture:string
 rake db:migrate
-ruby script\rails server
+ruby bin\rails server
 {% endhighlight %}
   </div>
 </div>


### PR DESCRIPTION
In rails 4.0.0 that is current stable version,
the `rails` script is placed under `bin` not `script`.
