### PR TITLE
Add an Explain step after Initial Commands

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -31,6 +31,7 @@ Where you start the rails server and run commands.
 </div>
 
 ### Important
+
 It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands.
 
 ## *1.*Creating the application
@@ -49,9 +50,37 @@ Next, type these commands in the terminal:
   <div class="nix">
 {% highlight sh %}
 mkdir projects
+{% endhighlight %}
+
+    <div>
+You can verify that a directory named <code>projects</code> was created by running the list command: <code>ls</code>. You should see the <code>projects</code> directory in the output. Now you want to change the directory you are currently in to the <code>projects</code> folder by running:
+    </div>
+
+{% highlight sh %}
 cd projects
+{% endhighlight %}
+
+    <div>
+You can verify you are now in an empty directory or folder by again running the <code>ls</code> command. Now you want to create a new app called <code>railsgirls</code> by running:
+    </div>
+
+{% highlight sh %}
 rails new railsgirls
+{% endhighlight %}
+
+    <div>
+This will create a new app in the folder <code>railsgirls</code>, so we again want to change the directory to be inside of our rails app by running:
+    </div>
+
+{% highlight sh %}
 cd railsgirls
+{% endhighlight %}
+
+    <div>
+If you run <code>ls</code> inside of the directory you should see folders such as <code>app</code> and <code>config</code>. You can then start the rails server by running:
+    </div>
+
+{% highlight sh %}
 rails server
 {% endhighlight %}
   </div>
@@ -59,9 +88,37 @@ rails server
   <div class="win">
 {% highlight sh %}
 mkdir projects
+{% endhighlight %}
+
+    <div>
+You can verify that a directory named <code>projects</code> was created by running the list command: <code>dir</code>. You should see the <code>projects</code> directory in the output. Now you want to change the directory you are currently in to the <code>projects</code> folder by running:
+    </div>
+
+{% highlight sh %}
 cd projects
+{% endhighlight %}
+
+    <div>
+You can verify you are now in an empty directory or folder by again running the <code>dir</code> command. Now you want to create a new app called <code>railsgirls</code> by running:
+    </div>
+
+{% highlight sh %}
 rails new railsgirls
+{% endhighlight %}
+
+    <div>
+This will create a new app in the folder <code>railsgirls</code>, so we again want to change the directory to be inside of our rails app by running:
+    </div>
+
+{% highlight sh %}
 cd railsgirls
+{% endhighlight %}
+
+    <div>
+If you run <code>dir</code> inside of the directory you should see folders such as <code>app</code> and <code>config</code>. You can then start the rails server by running:
+    </div>
+
+{% highlight sh %}
 ruby bin\rails server
 {% endhighlight %}
   </div>
@@ -70,6 +127,23 @@ ruby bin\rails server
 **Windows users:** You may need to replace `bin\rails` with `script\rails`, depending on the version of Rails you have installed.
 
 Open [http://localhost:3000](http://localhost:3000) in your browser. You should see "Welcome aboard" page, which means that the generation of your new app worked correctly.
+
+Notice in this window the command prompt is not visible because you are now in the Rails server, the command prompt looks like this:
+
+<div class="os-specific">
+  <div class="nix">
+{% highlight sh %}
+$
+{% endhighlight %}
+  </div>
+  <div class="win">
+{% highlight sh %}
+>
+{% endhighlight %}
+  </div>
+</div>
+
+When the command prompt is not visible you cannot execute new commands. If you try running `cd` or another command it will not work. To return to the normal command prompt:
 
 Hit `CTRL-C` in the terminal to quit the server.
 


### PR DESCRIPTION
Following the pattern: "prepare", "do", "explain"; we want to make the guide accessible to people without coach intervention (where possible). This style of instruction always starts off telling the individual what we will be doing, then tells how to do it, then tells how to check if our command worked correctly. This makes mistakes such as creating a `railsgirls` directory inside of an already existing `railsgirls` project much more difficult, or running `rails server` in the wrong directory.

Another super common mistake is to forget to stop/start the server before typing into it. Let's be a little more declarative about what the students are doing, and empower them to solve their own problems.
