### PR TITLE
Generate uploader before restarting server

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -200,13 +200,13 @@ In the terminal run:
 bundle
 {% endhighlight %}
 
-At this point you need to **restart the Rails server process** in the terminal. This is needed for the app to load the added library.
-
 Now we can generate the code for handling uploads. In the terminal run:
 
 {% highlight sh %}
 rails generate uploader Picture
 {% endhighlight %}
+
+At this point you need to **restart the Rails server process** in the terminal. This is needed for the app to load the added library.
 
 Open `app/models/idea.rb` and under the line
 


### PR DESCRIPTION
If you generate the uploader after you start the server you get an error because the constant cannot be found. 

This fixes that issue
