### PR TITLE
Splits the ideas scaffold instructions.

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -160,6 +160,21 @@ We're going to use Rails' scaffold functionality to generate a starting point th
   <div class="nix">
 {% highlight sh %}
 rails generate scaffold idea name:string description:text picture:string
+{% endhighlight %}
+  </div>
+
+  <div class="win">
+{% highlight sh %}
+rails generate scaffold idea name:string description:text picture:string
+{% endhighlight %}
+  </div>
+</div>
+
+The scaffold creates new files in your project directory, but to get it to work properly we need to run a couple of other commands to update our database and restart the server.
+
+<div class="os-specific">
+  <div class="nix">
+{% highlight sh %}
 rake db:migrate
 rails server
 {% endhighlight %}
@@ -167,7 +182,6 @@ rails server
 
   <div class="win">
 {% highlight sh %}
-rails generate scaffold idea name:string description:text picture:string
 rake db:migrate
 ruby bin\rails server
 {% endhighlight %}


### PR DESCRIPTION
This expands the instructions to create an `ideas` scaffold in the example app, mostly to overcome an issue that many attendees had (at least in the group I was in and mostly on windows): while pasting the scaffold generation command, they would also paste the subsequent `rake db:migrate` on the same line (probably an issue with line breaks), generating a broken scaffold.

By splitting the instructions into two, we can mitigate the issue.

I'm attaching a screenshot of the new version for ease of review.

![scaffold](https://f.cloud.github.com/assets/537608/1276337/4156e5c6-2e5d-11e3-8faa-c2915c4865a4.png)
