### PR TITLE
Add operation to force user redirect to login page if not logged in.

### DIFF
--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -111,7 +111,7 @@ Finally, be forced user to redirect to login page if user was not logged in. Ope
   before_action :authenticate_user!
 {% endhighlight %}
 
-before the `end` keyword.
+after `protect_from_forgery with: :exception`.
 
 Open your browser and try logging in and out from.
 


### PR DESCRIPTION
At the end of /devise, user can login/logout/signup with clicking top links. But user can view all pages even if user was not logged in. So, I Added redirect operation.
