### PR TITLE
Remove a line mentioning about installing git and ssh-keygen

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -125,8 +125,6 @@ Make sure that all works well by running the application generator command.
 rails new railsgirls
 {% endhighlight %}
 
-Installation of Git and SSH-keys is required if you want to [put your app online with Heroku](/heroku).
-
 **Final step.** You also need a text editor to edit code files. For the workshop we recommend the text editor Sublime Text.
 
 * [Download Sublime Text and install it](http://www.sublimetext.com/2)


### PR DESCRIPTION
RailsInstaller 2.2.2 contains git and generates ssh private and public keys.
