### PR TITLE
Check README.rdoc instead

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -40,13 +40,22 @@ This initializes a git repository in your project
 
 *Note:* If you've already done the [Heroku guide](/heroku), then you've already initialized a git repository & you can move on to the next steps.
 
-Next type:
+Next check if a file called `READEME.rdoc` exists in your railsgirl directory:
 
-`touch README`
+<div class="os-specific">
+  <div class="nix">
+    <code>ls README.rdoc</code>
+  </div>
+  <div class="win">
+    <code>dir README.rdoc</code>
+  </div>
+</div>
 
-This creates a file called "README" in your railsgirls directory
+If the file doesn't exist, create it by typing:
 
-**COACH:** Talk a little about READMEs
+`touch README.rdoc`
+
+**COACH:** Talk a little about README.rdoc
 
 Then type:
 


### PR DESCRIPTION
`rails new` command generates `README.rdoc` since Rails 4. So, Iwould like to propose to change to checking the existence of `README.rdoc` instead of creating `README` in [Push Your App to GitHub](http://guides.railsgirls.com/github/).
