### PR TITLE
Fix the rails new command for the Windows OS

### DIFF
--- a/_posts/2014-02-13-simple-app.markdown
+++ b/_posts/2014-02-13-simple-app.markdown
@@ -114,9 +114,15 @@ You can verify you are now in an empty directory or folder by again running the 
     </div>
 
 {% highlight sh %}
-rails new railsgirls
+rails new railsgirls -m http://railsgirls.com/simple_scaffold.rb
 {% endhighlight %}
 
+    <div>
+        <code>rails new railsgirls</code> tells Rails to generate a project called railsgirls with all the files that our application needs.
+    </div>
+    <div>
+        <code>-m http://railsgirls.com/simple_scaffold.rb</code> tells Rails to download a special template from railsgirls.com which makes the files a bit simpler and easier for beginners to understand.
+    </div>
     <div>
 This will create a new app in the folder <code>railsgirls</code>, so we again want to change the directory to be inside of our rails app by running:
     </div>


### PR DESCRIPTION
This is the simpleapp guide, which uses the simple_scaffold template.

The simple_scaffold template option was present only in the *NIX version of the guide and was missing from the windows one.

@Ben-M, was this left out intentionally?
