### PR TITLE
Add --no-ri --no-rdoc to "gem i" as well

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -98,7 +98,7 @@ rbenv global 2.1.1
 3-B-6. Install rails:
 
 {% highlight sh %}
-gem i rails
+gem i rails --no-ri --no-rdoc
 {% endhighlight %}
 
 **Final step.** Install a text editor to edit code files. For the workshop we recommend the text editor Sublime Text.


### PR DESCRIPTION
This matches the flags used in line 42:

   gem update rails --no-ri --no-rdoc

Without these flags, OS X 10.9 users could run into:

```
https://github.com/rails/rails/issues/11814
```

where installation seems to hang.
