### PR TITLE
Corrects styling for alert

### DIFF
--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -48,10 +48,10 @@ Open up `app/views/layouts/application.html.erb` and add:
 
 {% highlight erb %}
 <% if notice %>
-  <p class="alert alert-notice"><%= notice %></p>
+  <p class="alert alert-success"><%= notice %></p>
 <% end %>
 <% if alert %>
-  <p class="alert alert-error"><%= alert %></p>
+  <p class="alert alert-danger"><%= alert %></p>
 <% end %>
 {% endhighlight %}
 right above


### PR DESCRIPTION
In the guides for adding Devise, the alert classes were incorrectly
labeled as “alert-notice” and “alert-error.” This changes them to the
correct names so that the styling shows up. See
http://getbootstrap.com/components/#alerts for details.
