### PR TITLE
Fix typo in guide post links

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@ title: Guides
   <li>
     <i>11</i>
     <h3>Continuous Deployment</h3>
-    <p><a href="testing-rspec">Test your application with RSPec</a> | <a href="continuous-travis">CD with Travis (and anynines)</a> | <a href="continuous">CD with Codeship (and Heroku)</a></p>
+    <p><a href="testing-rspec">Test your application with RSpec</a> | <a href="continuous-travis">CD with Travis (and anynines)</a> | <a href="continuous">CD with Codeship (and Heroku)</a></p>
   </li>
 </ul>
 


### PR DESCRIPTION
Should be _RSpec_ instead of _RSPec_.
