### PR TITLE
Add rbenv-gem-rehash to the install guide

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -70,7 +70,7 @@ ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
 
 {% highlight sh %}
 brew update
-brew install rbenv ruby-build
+brew install rbenv rbenv-gem-rehash ruby-build
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 echo 'export PATH="$HOME/.rbenv/shims:$PATH"' >> ~/.bash_profile
 source ~/.bash_profile


### PR DESCRIPTION
We ran into problems when trying to verify the installation of the rails
stack via a simple `rails new railsgirls` since rbenv does not automatically
add shims for newly installed gems. The rbenv-gem-rehash plugin add this
behavior an fixes the problem.

This fixes #165 as well without the need for any further explanation of rbenv's internal workings
