### PR TITLE
On the commenting guide, add rake db:migrate after scaffold

### DIFF
--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -16,6 +16,10 @@ Create a comment scaffold, with the commentator name, the comment body (contents
 {% highlight sh %}
 rails g scaffold comment user_name:string body:text idea_id:integer
 {% endhighlight %}
+This will create a migration file that lets your database know about the new comments table. Run the migrations using
+{% highlight sh %}
+rake db:migrate
+{% endhighlight %}
 
 ## Step 2: Add relations to models
 


### PR DESCRIPTION
When coaching I noticed there was no rake db:migrate command in the commenting guide.  I've added a simple instruction explaining that it should be ran after the rails g scaffold command so that the database knows about the new comments table.
