### PR TITLE
Correct rails and rake commands

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -157,19 +157,9 @@ We're going to use Rails' scaffold functionality to generate a starting point th
 
 **Coach:** What is Rails scaffolding? (Explain the command, the model name and related database table, naming conventions, attributes and types, etc.) What are migrations and why do you need them?
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
 rails generate scaffold idea name:string description:text picture:string
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-rails generate scaffold idea name:string description:text picture:string
-{% endhighlight %}
-  </div>
-</div>
 
 The scaffold creates new files in your project directory, but to get it to work properly we need to run a couple of other commands to update our database and restart the server.
 


### PR DESCRIPTION
Correct rails and rake command syntaxes in the /app page.

I've checked this changes with follow environments (according to /install page)

[Windows] RailsInstaller, Ruby1.9.3p392/Rails4.1.0, Win 8.1
"rails" command use "bin/rails". (Using binstub and spring)
"rake" command don't use "bin/rake", so we need "ruby bin/rake" command.  ( "/" is correct in RailsInstaller shell. )

[Mac] rbenv Ruby2.1.2/Rails4.1.0
"rails" command use "bin/rails". (Using binstub and spring)
"rake" command don't use "bin/rake", so we need "bin/rake" command.

And remove a "script/rails" description.
