### PR TITLE
Only remove link color on immediate child.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -171,8 +171,8 @@ footer a {
   -moz-transition: 0.10s background-color ease-in;
 }
 
-.home a,
-.home a:hover {
+.home li > a,
+.home li > a:hover {
   color: inherit;
   text-decoration: none;
 }


### PR DESCRIPTION
It's not clear when smaller links are used due to the CSS turning off link colors in this `.home` section. This change only applies the color removal to immediate children, so links inside paragraphs can be allowed to be more visible.

**Before:**
![screenshot 2014-07-28 02 20 01](https://cloud.githubusercontent.com/assets/53273/3718611/6d8e8fae-1638-11e4-8808-30412911a344.png)

**After:**
![screenshot 2014-07-28 02 19 53](https://cloud.githubusercontent.com/assets/53273/3718614/79b84428-1638-11e4-84ae-71f33371e454.png)
