### PR TITLE
Updated version of mini_magick to 3.8.0

### DIFF
--- a/_posts/2012-06-03-thumbnails.markdown
+++ b/_posts/2012-06-03-thumbnails.markdown
@@ -28,7 +28,7 @@ used before?
 Open `Gemfile` in the project and add
 
 {% highlight ruby %}
-gem 'mini_magick', '3.5.0'
+gem 'mini_magick', '3.8.0'
 {% endhighlight %}
 
 under the line


### PR DESCRIPTION
3.5.0 is incompatible with Windows due to a lack of double quotes around the background option when it calls the command line executable.
