### PR TITLE
Replace text editor from SublimeText2 to Atom in the install page.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -110,7 +110,7 @@ For the workshop we recommend the text editor Atom.
 
 * [Download Atom and install it](https://atom.io/)
 
-If you are using Mac OS X 10.7 or before versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2).
+If you are using Mac OS X 10.7 or older versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2).
 
 ### *5.* Update your browser
 
@@ -156,7 +156,7 @@ For the workshop we recommend the text editor Atom.
   * Copy the folder into your Program Files.
   * Launch atom in the folder.
 
-If you are using Windows Vista or before versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2).
+If you are using Windows Vista or older versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2).
 
 Now you should have a working Ruby on Rails programming setup. Congrats!
 


### PR DESCRIPTION
I suggest changing text editor from SublimeText2 to Atom.

The biggest reason is their licenses.

Atom's license is MIT license. We can use freely. (And we can also avoid charging claim dialogs by SublimeText2.)

But in Linux case, I can't find install methods easily, so I leave SublimeText2 sentences as it is. (I'm happy to be replaced if you know good install methods in Linux.)
