### PR TITLE
Remove trailing slash in self-closing elements.

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -199,8 +199,8 @@ Open `app/views/layouts/application.html.erb` in your text editor and above the 
 add
 
 {% highlight erb %}
-<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap.css" />
-<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap-theme.css" />
+<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap.css">
+<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap-theme.css">
 {% endhighlight %}
 
 and replace


### PR DESCRIPTION
The HTML5 spec says they're optional:

http://dev.w3.org/html5/spec-author-view/syntax.html#syntax-start-tag
