### PR TITLE
Removes the bootstrap.css replacement

### DIFF
--- a/_posts/2013-01-20-design.markdown
+++ b/_posts/2013-01-20-design.markdown
@@ -12,20 +12,6 @@ Now the app is running well, but it still looks like scaffold. Let's add some de
 
 ## *1.*Adjust the application layout
 
-First, let's use bootstrap.min.css to apply a more lightweight style set to your app.
-
-Open `app/views/layouts/application.html.erb` in your text editor and replace the line
-
-{% highlight html %}
-<link rel="stylesheet" href="http://railsgirls.com/assets/bootstrap.css">
-{% endhighlight %}
-
-with
-
-{% highlight html %}
-<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap.min.css">
-{% endhighlight %}
-
 Open `app/assets/stylesheets/application.css`, replace the line
 
 {% highlight html %}


### PR DESCRIPTION
We should use the version from http://railsgirls.com/assets/bootstrap.css, not Bootstrap 2. With Bootstrap 2 it looked like this:
![bootstrap2](https://cloud.githubusercontent.com/assets/903551/4233646/ebc286e4-39ad-11e4-9dcb-e378fdc75e1b.png)
