### PR TITLE
Fixed installation URL of Homebrew

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -65,7 +65,7 @@ xcode-select --install
 #### *3b2.* Install [Homebrew](http://brew.sh/):
 
 {% highlight sh %}
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 {% endhighlight %}
 
 #### *3b3.* Install [rbenv](https://github.com/sstephenson/rbenv):


### PR DESCRIPTION
Fixed installation URL of [Homebrew](http://brew.sh/).

http://guides.railsgirls.com/install/
