### PR TITLE
Improve contributing guide

### DIFF
--- a/_posts/2012-04-19-contributing.markdown
+++ b/_posts/2012-04-19-contributing.markdown
@@ -11,12 +11,12 @@ The guides site uses [jekyll](https://github.com/mojombo/jekyll) to power the si
 1. Fork the [repository on github](https://github.com/railsgirls/railsgirls.github.com) by clicking on the "Fork" button.
 2. Do a `git clone` of your fork.
 3. Create a file named `YYYY-MM-DD-guide_name.markdown` inside the `_posts` directory of your fork.
-4. In this file, you'll need to add some YAML front matter at the top of the file so it looks like this:
+4. In this file, you'll need to add some YAML front matter at the top of the file so it looks like the following example, taken from this guide that you are currently viewing:
 {% highlight yaml %}
 ---
 layout: default
-title: Name of the Guide
-permalink: one-word-summary
+title: Contributing a Guide
+permalink: contributing
 ---
 {% endhighlight %}
 5. Commit this new guide to your git repo.


### PR DESCRIPTION
This PR is about the YAML Front Matter example.

It contains two fixes:
- The example code was not being formatted properly and was being shown on one line.
- The example code was using `.html` in the permalink, whereas none of the posts actually do.

And one, imo, improvement of the example code, which makes it more relatable as it can be compared to the guide the reader is viewing at that very moment.

---
### Before

![screen shot 2014-12-12 at 15 49 40](https://cloud.githubusercontent.com/assets/2320/5413407/82a4d908-8216-11e4-9f7d-d072f73d458a.png)
### After

![screen shot 2014-12-12 at 15 45 17](https://cloud.githubusercontent.com/assets/2320/5413399/671d11b4-8216-11e4-8417-3fab0598c854.png)
