### PR TITLE
Update sinatra-app-tutorial to Bootstrap 5.3.0 + minor changes

### DIFF
--- a/_pages/sinatra-app-tutorial.md
+++ b/_pages/sinatra-app-tutorial.md
@@ -260,11 +260,21 @@ require 'yaml/store'
 Add some more code into `suffragist.rb` – replace
 `post '/cast'` and `get '/results'` with the following:
 
+<!--
+Do not change the .yaml extension to .yml.
+
+rerun, the most popular solution for restarting Sinatra if source files change, watches for .yml
+files by default.
+
+As a result, if after an attendee starts using rerun, rerun will restart the server any time a vote
+is cast, leading to unexpected behavior from the app.
+-->
+
 {% highlight ruby %}
 post '/cast' do
   @title = 'Thanks for casting your vote!'
   @vote  = params['vote']
-  @store = YAML::Store.new 'votes.yml'
+  @store = YAML::Store.new 'votes.yaml'
   @store.transaction do
     @store['votes'] ||= {}
     @store['votes'][@vote] ||= 0
@@ -275,7 +285,7 @@ end
 
 get '/results' do
   @title = 'Results so far:'
-  @store = YAML::Store.new 'votes.yml'
+  @store = YAML::Store.new 'votes.yaml'
   @votes = @store.transaction { @store['votes'] }
   erb :results
 end
@@ -288,7 +298,7 @@ Explain what YAML is.
 
 ### See how the YAML file changes when votes are cast
 
-Let’s open `votes.yml`. And vote. And check again.
+Let’s open `votes.yaml`. And vote. And check again.
 
 {% coach %}
 There will be situations when one or more students will

--- a/_pages/sinatra-app-tutorial.md
+++ b/_pages/sinatra-app-tutorial.md
@@ -320,4 +320,5 @@ Try to change things in the app in any way you see fit:
 * Add some additional logic to the views.
 * Redirect to the results outright.
 * Add other votings; how would the YAML file need to change?
+* Sort the results by the number of votes.
 * Try to style the file in different ways.

--- a/_pages/sinatra-app-tutorial.md
+++ b/_pages/sinatra-app-tutorial.md
@@ -61,28 +61,33 @@ a directory for our views (and name it `views`).
 Put this code into an `index.erb` file in the `views` directory:
 
 {% highlight erb %}
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
-    <meta charset='UTF-8' />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Suffragist</title>
-    <link href='//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css' rel='stylesheet' />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
-  <body class='container'>
-    <p>What's for dinner?</p>
-    <form action='cast' method='post'>
-      <ul class='unstyled'>
-        <% Choices.each do |id, text| %>
-          <li>
-            <label class='radio'>
-              <input type='radio' name='vote' value='<%= id %>' id='vote_<%= id %>' />
-              <%= text %>
-            </label>
-          </li>
-        <% end %>
-      </ul>
-      <button type='submit' class='btn btn-primary'>Cast this vote!</button>
-    </form>
+  <body>
+    <div class="container">
+      <p>What's for dinner?</p>
+
+      <form action="cast" method="post">
+        <div class="mb-3">
+          <% Choices.each do |id, text| %>
+            <div class="form-check">
+              <input type="radio" name="vote" value="<%= id %>" class="form-check-input" id="vote_<%= id %>" />
+              <label class="form-check-label" for="vote_<%= id %>">
+                <%= text %>
+              </label>
+            </div>
+          <% end %>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Cast this vote!</button>
+      </form>
+    </div>
   </body>
 </html>
 {% endhighlight %}
@@ -122,9 +127,10 @@ Adjust the `index.erb` file in the `views`
 directory and add the `<h1>…</h1>` line:
 
 {% highlight erb %}
-  <body class='container'>
-    <h1><%= @title %></h1>
-    <p>What's for dinner?</p>
+  <body>
+    <div class="container">
+      <h1><%= @title %></h1>
+      <p>What's for dinner?</p>
 {% endhighlight %}
 
 Change the `get` action:
@@ -159,17 +165,20 @@ Create a new file in the `views` directory, `cast.erb`,
 and put there some HTML with embedded Ruby code:
 
 {% highlight erb %}
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
-    <meta charset='UTF-8' />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Suffragist</title>
-    <link href='//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css' rel='stylesheet' />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
-  <body class='container'>
-    <h1><%= @title %></h1>
-    <p>You cast: <%= Choices[@vote] %></p>
-    <p><a href='/results'>See the results!</a></p>
+  <body>
+    <div class="container">
+      <h1><%= @title %></h1>
+      <p>You cast: <%= Choices[@vote] %></p>
+      <p><a href="/results">See the results!</a></p>
+    </div>
   </body>
 </html>
 {% endhighlight %}
@@ -187,16 +196,20 @@ Create a `layout.erb` file in the `views`
 directory. Put the following in there:
 
 {% highlight erb %}
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
-    <meta charset='UTF-8' />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Suffragist</title>
-    <link href='//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css' rel='stylesheet' />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
-  <body class='container'>
-    <h1><%= @title %></h1>
-    <%= yield %>
+  <body>
+    <div class="container">
+      <h1><%= @title %></h1>
+      <%= yield %>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>
 {% endhighlight %}
@@ -225,7 +238,7 @@ end
 Create a new file in the `views` directory, called `results.erb`.
 
 {% highlight erb %}
-<table class='table table-hover table-striped'>
+<table class="table table-hover table-striped">
   <% Choices.each do |id, text| %>
     <tr>
       <th><%= text %></th>
@@ -234,7 +247,7 @@ Create a new file in the `views` directory, called `results.erb`.
     </tr>
   <% end %>
 </table>
-<p><a href='/'>Cast more votes!</a></p>
+<p><a href="/">Cast more votes!</a></p>
 {% endhighlight %}
 
 Run `ruby suffragist.rb`, check


### PR DESCRIPTION
The Sinatra tutorial was using Bootstrap 2.3.1 which is quite old, so I updated it to the newest 5.3.0.

* The Bootstrap JS file was added to enable attendees to use extra Bootstrap components without additional changes.
* Single quotes for HTML attributes have been changed to double quotes. Mostly so that if an attendee runs into a React app in the future, they won’t be caught off guard.

I tested the change by following the tutorial from scratch and verifying that the app looks the same as after manual Bootstrap update from 2.3.1.

This PR also changes `votes.yml` to `votes.yaml`. While `.yaml` does not adhere to Rails conventions (but does adhere to general Yaml conventions), this fixes an issue with using [rerun](https://github.com/alexch/rerun) with this app, as described in the comment.

I also added another idea for something attendees can work on after they're finished with the tutorial.