### PR TITLE
Update the checkbox name of ImageMagick installation wizard

### DIFF
--- a/_pages/thumbnails.md
+++ b/_pages/thumbnails.md
@@ -33,7 +33,7 @@ sudo apt-get install imagemagick
 {% endhighlight %}
   </div>
   <div class="win">
-<p>Download and run the <a href="https://www.imagemagick.org/script/download.php#windows">ImageMagick installer</a> (use the first <em>download</em> link). In the installation wizard, make sure you check the checkbox to install legacy binaries.</p>
+<p>Download and run the <a href="https://www.imagemagick.org/script/download.php#windows">ImageMagick installer</a> (use the first <em>download</em> link). In the installation wizard, make sure you check the checkbox to install legacy utilities.</p>
   </div>
 </div>
 

--- a/_pages/thumbnails.md
+++ b/_pages/thumbnails.md
@@ -21,19 +21,19 @@ We'll be using the ImageMagick tool to resize the pictures uploaded to your idea
 
 <div class="os-specific">
   <div class="mac">
-<p>Run the following command in the Terminal app:</p>
+    <p>Run the following command in the Terminal app:</p>
 {% highlight sh %}
 brew install imagemagick
 {% endhighlight %}
   </div>
   <div class="nix">
-<p>If you are on Ubuntu, run the following command in the Terminal app:</p>
+    <p>If you are on Ubuntu, run the following command in the Terminal app:</p>
 {% highlight sh %}
 sudo apt-get install imagemagick
 {% endhighlight %}
   </div>
   <div class="win">
-<p>Download and run the <a href="https://www.imagemagick.org/script/download.php#windows">ImageMagick installer</a> (use the first <em>download</em> link). In the installation wizard, make sure you check the checkbox to install legacy utilities.</p>
+    <p>Download and run the <a href="https://www.imagemagick.org/script/download.php#windows">ImageMagick installer</a> (use the first <em>download</em> link). In the installation wizard, make sure you check the checkbox to install legacy utilities.</p>
   </div>
 </div>
 


### PR DESCRIPTION
In the installation wizard, the checkbox name might have changed.

<img width="496" alt="wizard" src="https://github.com/railsgirls/guides.railsgirls.com/assets/752746/5275618f-d9c1-4d48-ad03-d12d62bbb78d">

I think some might be confused as to which box to check.
Maybe I'm overreacting.