### PR TITLE
Add steps to start rails server

### DIFF
--- a/_pages/uploads.md
+++ b/_pages/uploads.md
@@ -98,6 +98,8 @@ to this line and save it:
 <%= form.file_field :picture %>
 {% endhighlight %}
 
+Run `rails server`.
+
 In your browser open <http://localhost:3000/ideas/new>.  Your "New idea" form will now show a different element on the page for the "Picture" field. Instead of a text field a file chooser is visible, recognizable by either a "Browse..." or "Choose File" button.
 
 Fill in the form to create a new idea, but this time select a picture as well using this new element/button. Any random image you have on your laptop will do, it's just a test.


### PR DESCRIPTION
On the https://guides.railsgirls.com/uploads page, you have instructions to stop the rails server before installing the `gem "carrierwave"`, but there is no step to start the rails server afterwards.
Before the step to access http://localhost:3000/ideas/new, how about adding ```Run `rails server`.```?

Changed page:
<img width="1203" alt="screenshot1" src="https://github.com/railsgirls/guides.railsgirls.com/assets/14245262/c72765e8-aaff-4faf-8201-f9cd84e194c5">