### PR TITLE
Add sudo apt-get update

### DIFF
--- a/_pages/thumbnails.md
+++ b/_pages/thumbnails.md
@@ -29,7 +29,8 @@ brew install imagemagick
   <div class="nix">
     <p>If you are on Ubuntu, run the following command in the Terminal app:</p>
 {% highlight sh %}
-sudo apt-get install imagemagick
+sudo apt-get update
+sudo apt-get install -y imagemagick
 {% endhighlight %}
   </div>
   <div class="win">


### PR DESCRIPTION
The command to install ImageMagick on https://guides.railsgirls.com/thumbnails is listed under section `sudo apt-get install imagemagick`. However, just following that leads to the following failure.
```
$ sudo apt-get install imagemagick
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package imagemagick
```

To prevent such failures, it's necessary to run `sudo apt-get update` before the install. Also, adding the -y option to sudo apt-get install imagemagick eliminates the need to enter 'y' midway, which I think is better.