### PR TITLE
fix: improve contributor experience from the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ View the guides at https://guides.railsgirls.com or clone this repo and install 
 ### Installing jekyll
 
 ```
-$ cd railsgirls.github.io
+$ cd guides.railsgirls.com
 ```
 
 ```

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ exclude:
   - "vendor/gems/"
   - "vendor/ruby/"
 url: https://guides.railsgirls.com
-source_url: https://github.com/railsgirls/railsgirls.github.io/blob/master/
+source_url: https://github.com/railsgirls/guides.railsgirls.com/blob/main/
 plugins:
   - jekyll-redirect-from
 site_title: "Rails Girls Guides"


### PR DESCRIPTION
The canonical repo name for the source code is now `guides.railsgirls.com` while the former name was `railsgirls/railsgirls.github.io`.