### PR TITLE
fix: fix wrong template structure for /design in /thumbnails

### DIFF
--- a/_pages/thumbnails.md
+++ b/_pages/thumbnails.md
@@ -99,13 +99,13 @@ We haven't changed how the idea pictures are displayed, so it should still be sh
 Open `app/views/ideas/_idea.html.erb` and change the line:
 
 {% highlight erb %}
-<%= image_tag(@idea.picture_url, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if @idea.picture? %>
+<%= image_tag(idea.picture_url, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture? %>
 {% endhighlight %}
 
 to this line:
 
 {% highlight erb %}
-<%= image_tag(@idea.picture_url(:thumb), width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if @idea.picture? %>
+<%= image_tag(idea.picture_url(:thumb), width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture? %>
 {% endhighlight %}
 
 Take a look at the [list of ideas](http://localhost:3000/ideas) in the Browser to see if your ideas now have a thumbnail.

--- a/_pages/thumbnails.md
+++ b/_pages/thumbnails.md
@@ -96,7 +96,7 @@ The images uploaded from now on will be resized to a smaller size, but the ones 
 
 We haven't changed how the idea pictures are displayed, so it should still be showing the original larger image. Let's change the views to display the thumbnail instead.
 
-Open `app/views/ideas/index.html.erb` and change the line:
+Open `app/views/ideas/_idea.html.erb` and change the line:
 
 {% highlight erb %}
 <%= image_tag(@idea.picture_url, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if @idea.picture? %>


### PR DESCRIPTION
As d002c40 (2023-02) split the template into the two: the parent index and the partial, https://guides.railsgirls.com/thumbnails#display-the-thumbnail (Display the thumbnail section in Create picture thumbnails
) has been inconsistent for 8+ months.

- Follows up d002c40
