### PR TITLE
Update "Logout" link for Rails 7 Turbo in "Adding Authentication with Devise" guide

### DIFF
--- a/_pages/devise.md
+++ b/_pages/devise.md
@@ -87,7 +87,7 @@ In order to do that, edit `app/views/layouts/application.html.erb` add:
 <% if user_signed_in? %>
   Logged in as <strong><%= current_user.email %></strong>.
   <%= link_to "Edit profile", edit_user_registration_path, class: "navbar-link" %> |
-  <%= link_to "Logout", destroy_user_session_path, method: :delete, class: "navbar-link"  %>
+  <%= link_to "Logout", destroy_user_session_path, data: { turbo_method: :delete }, class: "navbar-link"  %>
 <% else %>
   <%= link_to "Sign up", new_user_registration_path, class: "navbar-link"  %> |
   <%= link_to "Login", new_user_session_path, class: "navbar-link"  %>


### PR DESCRIPTION
This pull request should update "Logout" link in example of "Add sign-up and login links" on ["Adding Authentication with Devise"(https://guides.railsgirls.com/devise) guide.

See https://github.com/heartcombo/devise/wiki/How-To:-Upgrade-to-Devise-4.9.0-%5BHotwire-Turbo-integration%5D#data-method-vs-data-turbo-method for reference.

This issue is reported in railsgirls-jp/railsgirls.jp#599