### PR TITLE
fix: change the pathname SQLite3 in accordance with Rails 7.1

### DIFF
--- a/_pages/deployment/fly-io.md
+++ b/_pages/deployment/fly-io.md
@@ -57,7 +57,7 @@ Open the `config/database.yml` file in your Text Editor. Change the following li
 {% highlight yaml %}
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3
 {% endhighlight %}
 
 to these lines:

--- a/_pages/digital-ocean.md
+++ b/_pages/digital-ocean.md
@@ -51,7 +51,7 @@ Open the `config/database.yml` file in your Text Editor. Change the following li
 {% highlight yaml %}
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3
 {% endhighlight %}
 
 to these lines:

--- a/_pages/heroku.md
+++ b/_pages/heroku.md
@@ -49,7 +49,7 @@ Change the following lines in the file:
 {% highlight yaml %}
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3
 {% endhighlight %}
 
 to these lines:


### PR DESCRIPTION
- Follows up https://github.com/rails/rails/pull/46699

In Rails 7.1, the database pathname for SQLite3 was changed: see https://github.com/rails/rails/pull/46699

## Checklist

- [ ] There is no more occurrence of `database: db/*.sqlite3` once this change is merged:
    ```
    $ git grep 'database: db' | wc -l
    0
    ```