### PR TITLE
fix(#603): enable dark mode and light mode toggle for the ui

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-24
+  arm64-darwin-25
   x64-mingw-ucrt
   x86_64-darwin-20
   x86_64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,11 +10,15 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    ffi (1.17.0)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x64-mingw-ucrt)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
+    google-protobuf (4.27.5)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.27.5-arm64-darwin)
       bigdecimal
       rake (>= 13)
@@ -71,11 +75,32 @@ GEM
     rexml (3.4.2)
     rouge (4.3.0)
     safe_yaml (1.0.5)
+    sass-embedded (1.77.8)
+      google-protobuf (~> 4.26)
+      rake (>= 13)
+    sass-embedded (1.77.8-aarch64-linux-android)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-arm-linux-androideabi)
+      google-protobuf (~> 4.26)
     sass-embedded (1.77.8-arm64-darwin)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-riscv64-linux-android)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-riscv64-linux-gnu)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-riscv64-linux-musl)
       google-protobuf (~> 4.26)
     sass-embedded (1.77.8-x64-mingw-ucrt)
       google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86-cygwin)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86-linux-android)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86_64-cygwin)
+      google-protobuf (~> 4.26)
     sass-embedded (1.77.8-x86_64-darwin)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86_64-linux-android)
       google-protobuf (~> 4.26)
     sass-embedded (1.77.8-x86_64-linux-gnu)
       google-protobuf (~> 4.26)
@@ -85,14 +110,20 @@ GEM
     webrick (1.8.2)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-24
-  arm64-darwin-25
+  aarch64-linux-android
+  arm-linux-androideabi
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
   x64-mingw-ucrt
-  x86_64-darwin-20
+  x86-cygwin
+  x86-linux-android
+  x86_64-cygwin
+  x86_64-darwin
   x86_64-linux
+  x86_64-linux-android
 
 DEPENDENCIES
   jekyll
@@ -100,4 +131,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.17
+   2.7.2

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,13 +11,24 @@
         <a href="https://railsgirls.tumblr.com/">Blog</a>
         <a href="/guide">Organizers</a>
         <a href="/">Guides</a>
+        <button
+          class="theme-toggle"
+          type="button"
+          aria-label="Switch to dark theme"
+          data-theme-toggle
+        >
+          Dark Mode
+        </button>
       </nav>
     </div>
 
     <!-- Phone/Tablet -->
     <div class="visible-tablet visible-phone">
       <div class="nav navbar nav-pills">
-        <a class="btn btn-link btn-navbar collapsed" onclick="toggleMobileMenu()">
+        <a
+          class="btn btn-link btn-navbar collapsed"
+          onclick="toggleMobileMenu()"
+        >
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -25,7 +36,20 @@
 
         <a class="brand" href="/">Rails Girls Guides</a>
 
-        <div class="nav-collapse navbar-responsive-collapse navbar-collapse" id='navbar-list' style='height: 0;'>
+        <button
+          class="theme-toggle theme-toggle-mobile"
+          type="button"
+          aria-label="Switch to dark theme"
+          data-theme-toggle
+        >
+          Dark Mode
+        </button>
+
+        <div
+          class="nav-collapse navbar-responsive-collapse navbar-collapse"
+          id="navbar-list"
+          style="height: 0"
+        >
           <ul class="nav">
             <li><a href="https://railsgirls.com/">Home</a></li>
             <li><a href="https://railsgirls.com/events.html">Events</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,24 +11,14 @@
         <a href="https://railsgirls.tumblr.com/">Blog</a>
         <a href="/guide">Organizers</a>
         <a href="/">Guides</a>
-        <button
-          class="theme-toggle"
-          type="button"
-          aria-label="Switch to dark theme"
-          data-theme-toggle
-        >
-          Dark Mode
-        </button>
+        <button class="theme-toggle" type="button" aria-label="Switch to dark theme" data-theme-toggle>Dark Mode</button>
       </nav>
     </div>
 
     <!-- Phone/Tablet -->
     <div class="visible-tablet visible-phone">
       <div class="nav navbar nav-pills">
-        <a
-          class="btn btn-link btn-navbar collapsed"
-          onclick="toggleMobileMenu()"
-        >
+        <a class="btn btn-link btn-navbar collapsed" onclick="toggleMobileMenu()">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -36,20 +26,9 @@
 
         <a class="brand" href="/">Rails Girls Guides</a>
 
-        <button
-          class="theme-toggle theme-toggle-mobile"
-          type="button"
-          aria-label="Switch to dark theme"
-          data-theme-toggle
-        >
-          Dark Mode
-        </button>
+        <button class="theme-toggle theme-toggle-mobile" type="button" aria-label="Switch to dark theme" data-theme-toggle>Dark Mode</button>
 
-        <div
-          class="nav-collapse navbar-responsive-collapse navbar-collapse"
-          id="navbar-list"
-          style="height: 0"
-        >
+        <div class="nav-collapse navbar-responsive-collapse navbar-collapse" id='navbar-list' style='height: 0;'>
           <ul class="nav">
             <li><a href="https://railsgirls.com/">Home</a></li>
             <li><a href="https://railsgirls.com/events.html">Events</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
         <a href="https://railsgirls.tumblr.com/">Blog</a>
         <a href="/guide">Organizers</a>
         <a href="/">Guides</a>
-        <button class="theme-toggle" type="button" aria-label="Switch to dark theme" data-theme-toggle>Dark Mode</button>
+        <button class="theme-toggle" type="button" data-theme-toggle>Dark Mode</button>
       </nav>
     </div>
 
@@ -26,7 +26,7 @@
 
         <a class="brand" href="/">Rails Girls Guides</a>
 
-        <button class="theme-toggle theme-toggle-mobile" type="button" aria-label="Switch to dark theme" data-theme-toggle>Dark Mode</button>
+        <button class="theme-toggle theme-toggle-mobile" type="button" data-theme-toggle>Dark Mode</button>
 
         <div class="nav-collapse navbar-responsive-collapse navbar-collapse" id='navbar-list' style='height: 0;'>
           <ul class="nav">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,23 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <script>
+      (function() {
+        var storedTheme = null;
+
+        try {
+          storedTheme = localStorage.getItem("theme");
+        } catch (error) {}
+
+        var theme = storedTheme;
+        if (theme !== "light" && theme !== "dark") {
+          theme = window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+
+        document.documentElement.setAttribute("data-theme", theme);
+      })();
+    </script>
     {% capture page_title_capture %}
       {% if page.title == nil %}
         {{ site.site_title }}
@@ -36,6 +53,7 @@
     <link href="/css/style.css" rel="stylesheet" />
     <link href="/favicon.png" rel="shortcut icon" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
 
     <meta property="og:site_name" content="{{ site.site_title }}">
     <meta property="og:title" content="{{ page_title }}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,6 @@
     <link href="/css/style.css" rel="stylesheet" />
     <link href="/favicon.png" rel="shortcut icon" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="color-scheme" content="light dark">
 
     <meta property="og:site_name" content="{{ site.site_title }}">
     <meta property="og:title" content="{{ page_title }}">

--- a/css/code.css
+++ b/css/code.css
@@ -1,3 +1,17 @@
+.highlight {
+  color: var(--code-text);
+  background: var(--code-background);
+  border: 1px solid var(--code-border);
+  border-radius: 8px;
+}
+
+.highlight pre {
+  margin: 0;
+  padding: 14px 16px;
+  color: inherit;
+  background: transparent;
+}
+
 .highlight .hll { background-color: #ffffcc }
 /*.highlight  { background: #f0f0f0; }*/
 .highlight .c { color: #60a0b0; font-style: italic } /* Comment */
@@ -60,3 +74,52 @@
 .highlight .vg { color: #bb60d5 } /* Name.Variable.Global */
 .highlight .vi { color: #bb60d5 } /* Name.Variable.Instance */
 .highlight .il { color: #40a070 } /* Literal.Number.Integer.Long */
+
+html[data-theme="dark"] .highlight .hll { background-color: #3b3419 }
+html[data-theme="dark"] .highlight .c,
+html[data-theme="dark"] .highlight .cm,
+html[data-theme="dark"] .highlight .c1,
+html[data-theme="dark"] .highlight .cs { color: #8bb7c8 }
+html[data-theme="dark"] .highlight .k,
+html[data-theme="dark"] .highlight .kc,
+html[data-theme="dark"] .highlight .kd,
+html[data-theme="dark"] .highlight .kn,
+html[data-theme="dark"] .highlight .kr,
+html[data-theme="dark"] .highlight .ow,
+html[data-theme="dark"] .highlight .kp { color: #f2c879 }
+html[data-theme="dark"] .highlight .o,
+html[data-theme="dark"] .highlight .w,
+html[data-theme="dark"] .highlight .go { color: #a2a2a2 }
+html[data-theme="dark"] .highlight .m,
+html[data-theme="dark"] .highlight .mf,
+html[data-theme="dark"] .highlight .mh,
+html[data-theme="dark"] .highlight .mi,
+html[data-theme="dark"] .highlight .mo,
+html[data-theme="dark"] .highlight .il { color: #8cdca8 }
+html[data-theme="dark"] .highlight .s,
+html[data-theme="dark"] .highlight .sb,
+html[data-theme="dark"] .highlight .sc,
+html[data-theme="dark"] .highlight .sd,
+html[data-theme="dark"] .highlight .s1,
+html[data-theme="dark"] .highlight .s2,
+html[data-theme="dark"] .highlight .se,
+html[data-theme="dark"] .highlight .sh,
+html[data-theme="dark"] .highlight .si,
+html[data-theme="dark"] .highlight .sx,
+html[data-theme="dark"] .highlight .sr,
+html[data-theme="dark"] .highlight .ss { color: #9ecbff }
+html[data-theme="dark"] .highlight .na,
+html[data-theme="dark"] .highlight .nc,
+html[data-theme="dark"] .highlight .nn,
+html[data-theme="dark"] .highlight .nt,
+html[data-theme="dark"] .highlight .nf { color: #7fd4ff }
+html[data-theme="dark"] .highlight .nb,
+html[data-theme="dark"] .highlight .bp { color: #c9df86 }
+html[data-theme="dark"] .highlight .no,
+html[data-theme="dark"] .highlight .nv,
+html[data-theme="dark"] .highlight .vc,
+html[data-theme="dark"] .highlight .vg,
+html[data-theme="dark"] .highlight .vi { color: #d9a4ff }
+html[data-theme="dark"] .highlight .gp,
+html[data-theme="dark"] .highlight .ni,
+html[data-theme="dark"] .highlight .sx { color: #ffb07e }

--- a/css/code.css
+++ b/css/code.css
@@ -105,7 +105,6 @@ html[data-theme="dark"] .highlight .s2,
 html[data-theme="dark"] .highlight .se,
 html[data-theme="dark"] .highlight .sh,
 html[data-theme="dark"] .highlight .si,
-html[data-theme="dark"] .highlight .sx,
 html[data-theme="dark"] .highlight .sr,
 html[data-theme="dark"] .highlight .ss { color: #9ecbff }
 html[data-theme="dark"] .highlight .na,

--- a/css/style.css
+++ b/css/style.css
@@ -1,12 +1,68 @@
 html {
   --highlight: #e0330c;
-  background: #f4f4f4;
+  --page-background: #f4f4f4;
+  --surface-background: #ffffff;
+  --text-color: #333333;
+  --muted-text: #666666;
+  --border-color: #dddddd;
+  --header-background: #d3360b;
+  --header-link: #ffffff;
+  --header-link-hover: #f6e58d;
+  --footer-background: #f4f4f4;
+  --footer-link: #111111;
+  --guide-icon-background: #d0d0d0;
+  --guide-icon-hover: #d3360b;
+  --notice-background: #fef8ea;
+  --coach-border: #8102bb;
+  --kbd-background: #f7f7f7;
+  --kbd-border: #cccccc;
+  --kbd-shadow: #ffffff;
+  --kbd-text: #333333;
+  --code-background: #f8f8f8;
+  --code-border: #e2e2e2;
+  --code-text: #2f2f2f;
+  --scroll-button: #d3360b;
+  --scroll-button-hover: #555555;
+  background: var(--page-background);
+}
+
+html[data-theme="dark"] {
+  --highlight: #ff8f70;
+  --page-background: #161616;
+  --surface-background: #1f1f1f;
+  --text-color: #e6e1dc;
+  --muted-text: #bcb5ac;
+  --border-color: #454545;
+  --header-background: #8a2508;
+  --header-link: #fff4eb;
+  --header-link-hover: #ffd38a;
+  --footer-background: #191919;
+  --footer-link: #f4ddcf;
+  --guide-icon-background: #4f4f4f;
+  --guide-icon-hover: #c9471d;
+  --notice-background: #34291b;
+  --coach-border: #bb7ae4;
+  --kbd-background: #2b2b2b;
+  --kbd-border: #555555;
+  --kbd-shadow: #1c1c1c;
+  --kbd-text: #f1ece7;
+  --code-background: #101010;
+  --code-border: #2f2f2f;
+  --code-text: #f1ece7;
+  --scroll-button: #c9471d;
+  --scroll-button-hover: #7a7a7a;
+}
+
+html,
+body {
+  background: var(--page-background);
+  color: var(--text-color);
 }
 
 body {
   margin: 0px;
-  background: #fff;
-  color: #333;
+  background: var(--surface-background);
+  color: var(--text-color);
   text-rendering: optimizeLegibility;
   font-size: 15px;
   line-height: 1.6;
@@ -66,7 +122,7 @@ a:hover {
 }
 
 hr {
-  border-top-color: #ddd;
+  border-top-color: var(--border-color);
   margin: 2em 0;
 }
 
@@ -76,9 +132,9 @@ table {
 
 header {
   min-height: 60px;
-  color: #fff;
+  color: var(--header-link);
   padding-top: 20px;
-  background: #d3360b;
+  background: var(--header-background);
   position: sticky;
   top: 0;
   overflow: hidden;
@@ -100,7 +156,7 @@ nav {
 
 nav a,
 nav a:focus {
-  color: #fff;
+  color: var(--header-link);
   text-decoration: none;
   font-weight: 300;
   font-size: 20px;
@@ -115,7 +171,7 @@ nav a:after {
 
 nav a:focus {
   outline-offset: 10px;
-  outline: 2px dashed white;
+  outline: 2px dashed var(--header-link);
 }
 
 nav a:last-child:after {
@@ -127,17 +183,17 @@ nav a:hover {
 }
 
 footer {
-  color: #666;
+  color: var(--muted-text);
   overflow: hidden;
   width: 100%;
   padding: 40px 0;
-  background: #f4f4f4;
+  background: var(--footer-background);
   line-height: 1.5;
   text-align: center;
 }
 footer a {
-  color: #111;
-  border-color: #111;
+  color: var(--footer-link);
+  border-color: var(--footer-link);
 }
 footer p:last-child {
   margin-bottom: 0;
@@ -161,7 +217,7 @@ footer p:last-child {
   min-height: 84px;
 }
 .guides-list li:not(:last-child) {
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid var(--border-color);
 }
 .guides-list h3 {
   margin: 0;
@@ -188,7 +244,7 @@ footer p:last-child {
   font-weight: bold;
   text-align: center;
 
-  background-color: #d0d0d0;
+  background-color: var(--guide-icon-background);
   border-radius: 70px;
   transition: 0.1s background-color ease-in;
   -webkit-transition: 0.1s background-color ease-in;
@@ -208,7 +264,7 @@ footer p:last-child {
 }
 a:hover .guide-icon,
 .guide-icon:hover {
-  background-color: #d3360b;
+  background-color: var(--guide-icon-hover);
   transition: 0.1s background-color ease-in;
   -webkit-transition: 0.1s background-color ease-in;
   -moz-transition: 0.1s background-color ease-in;
@@ -373,7 +429,7 @@ i.icon-small-browser {
   margin-bottom: 20px;
   padding: 2px 10px;
 
-  border: 2px solid #ddd;
+  border: 2px solid var(--border-color);
   border-radius: 10px;
 }
 .os-specific.big .picker-options a.active,
@@ -395,18 +451,18 @@ i.icon-small-browser {
 
 kbd {
   padding: 0.1em 0.6em;
-  border: 1px solid #ccc;
+  border: 1px solid var(--kbd-border);
   font-size: 11px;
   font-family: Arial, Helvetica, sans-serif;
-  background-color: #f7f7f7;
-  color: #333;
-  -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
-  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
+  background-color: var(--kbd-background);
+  color: var(--kbd-text);
+  -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px var(--kbd-shadow) inset;
+  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px var(--kbd-shadow) inset;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px var(--kbd-shadow) inset;
   border-radius: 3px;
   display: inline-block;
   margin: 0 0.1em;
-  text-shadow: 0 1px 0 #fff;
+  text-shadow: none;
   line-height: 1.5em;
   white-space: nowrap;
 }
@@ -444,7 +500,7 @@ kbd {
   line-height: 24px;
   font-size: 22px;
   font-weight: 400;
-  color: #fff;
+  color: var(--header-link);
   text-shadow: none;
 }
 
@@ -455,7 +511,7 @@ kbd {
   padding: 7px 10px;
   margin-right: 5px;
   margin-left: 5px;
-  color: #ffffff;
+  color: var(--header-link);
   text-shadow: none;
   background-color: inherit;
   border: none;
@@ -469,7 +525,7 @@ kbd {
 .navbar .btn-navbar.active,
 .navbar .btn-navbar.disabled,
 .navbar .btn-navbar[disabled] {
-  color: #ffffff;
+  color: var(--header-link);
   background-color: inherit;
   *background-color: inherit;
 }
@@ -478,13 +534,13 @@ kbd {
   display: block;
   width: 18px;
   height: 4px;
-  background-color: #fff;
+  background-color: var(--header-link);
   box-shadow: none;
 }
 
 .navbar .nav > li > a {
   float: none;
-  color: #fff;
+  color: var(--header-link);
   font-weight: 400;
   text-decoration: none;
   text-shadow: none;
@@ -493,9 +549,43 @@ kbd {
 .navbar .nav > li > a:focus,
 .navbar .nav > li > a:hover,
 nav a:hover {
-  color: #f6e58d;
+  color: var(--header-link-hover);
   text-decoration: none;
   background-color: transparent;
+}
+
+.theme-toggle {
+  margin-left: 14px;
+  padding: 6px 12px;
+  color: var(--header-link);
+  font: inherit;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.2;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 999px;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  color: var(--header-link-hover);
+  border-color: currentcolor;
+  text-decoration: none;
+}
+
+.theme-toggle:focus {
+  outline: none;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 3px;
+}
+
+.theme-toggle-mobile {
+  float: right;
+  margin: 7px 5px 0 0;
 }
 
 [class*="-notice"] {
@@ -508,17 +598,17 @@ nav a:hover {
   margin-bottom: 0;
 }
 .guide-notice {
-  background-color: #fef8ea;
+  background-color: var(--notice-background);
 }
 .help-notice {
-  background-color: #fef8ea;
+  background-color: var(--notice-background);
 }
 .help-notice:before {
   content: "ℹ️";
   margin-right: 10px;
 }
 .coach-notice {
-  border: 2px solid #8102bb;
+  border: 2px solid var(--coach-border);
 }
 .coach-notice > div {
   cursor: help;
@@ -543,7 +633,7 @@ nav a:hover {
   font-size: 18px;
   border: none;
   outline: none;
-  background-color: red;
+  background-color: var(--scroll-button);
   color: white;
   cursor: pointer;
   padding: 14px;
@@ -551,7 +641,7 @@ nav a:hover {
   transition: all .4s;
 }
 .go-to-top-arrow:hover {
-  background-color: #555;
+  background-color: var(--scroll-button-hover);
 }
 .go-to-top-arrow.active{
   visibility: visible;

--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,7 @@ html {
   --code-border: #e2e2e2;
   --code-text: #2f2f2f;
   --scroll-button-hover: #555555;
+  color-scheme: light;
   background: var(--page-background);
 }
 
@@ -45,6 +46,7 @@ html[data-theme="dark"] {
   --code-border: #2f2f2f;
   --code-text: #f1ece7;
   --scroll-button-hover: #7a7a7a;
+  color-scheme: dark;
 }
 
 body {

--- a/css/style.css
+++ b/css/style.css
@@ -8,20 +8,17 @@ html {
   --header-background: #d3360b;
   --header-link: #ffffff;
   --header-link-hover: #f6e58d;
-  --footer-background: #f4f4f4;
   --footer-link: #111111;
   --guide-icon-background: #d0d0d0;
-  --guide-icon-hover: #d3360b;
+  --accent: #d3360b;
   --notice-background: #fef8ea;
   --coach-border: #8102bb;
   --kbd-background: #f7f7f7;
   --kbd-border: #cccccc;
   --kbd-shadow: #ffffff;
-  --kbd-text: #333333;
   --code-background: #f8f8f8;
   --code-border: #e2e2e2;
   --code-text: #2f2f2f;
-  --scroll-button: #d3360b;
   --scroll-button-hover: #555555;
   background: var(--page-background);
 }
@@ -36,20 +33,17 @@ html[data-theme="dark"] {
   --header-background: #8a2508;
   --header-link: #fff4eb;
   --header-link-hover: #ffd38a;
-  --footer-background: #191919;
   --footer-link: #f4ddcf;
   --guide-icon-background: #4f4f4f;
-  --guide-icon-hover: #c9471d;
+  --accent: #c9471d;
   --notice-background: #34291b;
   --coach-border: #bb7ae4;
   --kbd-background: #2b2b2b;
   --kbd-border: #555555;
   --kbd-shadow: #1c1c1c;
-  --kbd-text: #f1ece7;
   --code-background: #101010;
   --code-border: #2f2f2f;
   --code-text: #f1ece7;
-  --scroll-button: #c9471d;
   --scroll-button-hover: #7a7a7a;
 }
 
@@ -181,7 +175,7 @@ footer {
   overflow: hidden;
   width: 100%;
   padding: 40px 0;
-  background: var(--footer-background);
+  background: var(--page-background);
   line-height: 1.5;
   text-align: center;
 }
@@ -258,7 +252,7 @@ footer p:last-child {
 }
 a:hover .guide-icon,
 .guide-icon:hover {
-  background-color: var(--guide-icon-hover);
+  background-color: var(--accent);
   transition: 0.1s background-color ease-in;
   -webkit-transition: 0.1s background-color ease-in;
   -moz-transition: 0.1s background-color ease-in;
@@ -449,7 +443,7 @@ kbd {
   font-size: 11px;
   font-family: Arial, Helvetica, sans-serif;
   background-color: var(--kbd-background);
-  color: var(--kbd-text);
+  color: var(--code-text);
   -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px var(--kbd-shadow) inset;
   -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px var(--kbd-shadow) inset;
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px var(--kbd-shadow) inset;
@@ -627,7 +621,7 @@ nav a:hover {
   font-size: 18px;
   border: none;
   outline: none;
-  background-color: var(--scroll-button);
+  background-color: var(--accent);
   color: white;
   cursor: pointer;
   padding: 14px;

--- a/css/style.css
+++ b/css/style.css
@@ -53,12 +53,6 @@ html[data-theme="dark"] {
   --scroll-button-hover: #7a7a7a;
 }
 
-html,
-body {
-  background: var(--page-background);
-  color: var(--text-color);
-}
-
 body {
   margin: 0px;
   background: var(--surface-background);
@@ -462,7 +456,7 @@ kbd {
   border-radius: 3px;
   display: inline-block;
   margin: 0 0.1em;
-  text-shadow: none;
+  text-shadow: 0 1px 0 var(--kbd-shadow);
   line-height: 1.5em;
   white-space: nowrap;
 }

--- a/js/guides.js
+++ b/js/guides.js
@@ -49,10 +49,9 @@ function initializeThemeToggle() {
   applyTheme(getTheme());
 
   $('[data-theme-toggle]').click(function() {
-    var nextTheme =
-      document.documentElement.getAttribute('data-theme') === 'dark'
-        ? 'light'
-        : 'dark';
+    var nextTheme = document.documentElement.getAttribute('data-theme') === 'dark' ?
+      'light' :
+      'dark';
     saveTheme(nextTheme);
     applyTheme(nextTheme);
   });

--- a/js/guides.js
+++ b/js/guides.js
@@ -1,13 +1,73 @@
 function saveOs(os) {
-  Cookies.set("os", os, { expires: 1825, path: '/' }); // expires in 5 years
+  Cookies.set("os", os, { expires: 1825, path: "/" }); // expires in 5 years
+}
+
+function getPreferredTheme() {
+  return window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function getStoredTheme() {
+  try {
+    return localStorage.getItem("theme");
+  } catch (error) {
+    return null;
+  }
+}
+
+function getTheme() {
+  var storedTheme = getStoredTheme();
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
+  return getPreferredTheme();
+}
+
+function saveTheme(theme) {
+  try {
+    localStorage.setItem("theme", theme);
+  } catch (error) {}
+}
+
+function updateThemeToggleLabels(theme) {
+  var nextTheme = theme === "dark" ? "light" : "dark";
+  var ariaLabel = "Switch to " + nextTheme + " theme";
+  var buttonLabel = nextTheme === "dark" ? "Dark Mode" : "Light Mode";
+
+  $("[data-theme-toggle]").text(buttonLabel).attr("aria-label", ariaLabel);
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+  updateThemeToggleLabels(theme);
+}
+
+function initializeThemeToggle() {
+  applyTheme(getTheme());
+
+  $("[data-theme-toggle]").click(function () {
+    var nextTheme =
+      document.documentElement.getAttribute("data-theme") === "dark"
+        ? "light"
+        : "dark";
+    saveTheme(nextTheme);
+    applyTheme(nextTheme);
+  });
 }
 
 function loadOs() {
   var osFromCookie = Cookies.get("os");
-  if(osFromCookie) {
-    $(".os-specific").find("." + osFromCookie + "-link").click();
-  } else if(detectOs()) {
-    $(".os-specific").find("." + detectOs() + "-link").click();
+  if (osFromCookie) {
+    $(".os-specific")
+      .find("." + osFromCookie + "-link")
+      .click();
+  } else if (detectOs()) {
+    $(".os-specific")
+      .find("." + detectOs() + "-link")
+      .click();
   } else {
     $(".os-specific").find(".win-link").click();
   }
@@ -23,15 +83,23 @@ function detectOs() {
     } else {
       return "nix";
     }
-  } catch(e) {
+  } catch (e) {
     return false;
   }
 }
 
 function addIcons() {
-  $("code.language-sh, code.language-bat").closest('.highlight').before('<i class="icon-small-prompt"></i>');
-  $("code.language-erb, code.language-html, code.language-ruby, code.language-css").closest('.highlight').before('<i class="icon-small-text-editor"></i>');
-  $("code.language-browser").closest('.highlight').before('<i class="icon-small-browser"></i>');
+  $("code.language-sh, code.language-bat")
+    .closest(".highlight")
+    .before('<i class="icon-small-prompt"></i>');
+  $(
+    "code.language-erb, code.language-html, code.language-ruby, code.language-css",
+  )
+    .closest(".highlight")
+    .before('<i class="icon-small-text-editor"></i>');
+  $("code.language-browser")
+    .closest(".highlight")
+    .before('<i class="icon-small-browser"></i>');
 }
 
 function initializeOsSwitchers() {
@@ -39,14 +107,14 @@ function initializeOsSwitchers() {
   var switcher = osInstructions.prepend(
     "<span class='picker'><span class='picker-label'>Choose your Operating System:</span> " +
       "<span class='picker-options'>" +
-        "<span><a href='#' class='os-link win-link'>Windows</a></span>" +
-        "<span><a href='#' class='os-link mac-link'>Mac</a></span>" +
-        "<span><a href='#' class='os-link nix-link'>Linux</a></span>" +
+      "<span><a href='#' class='os-link win-link'>Windows</a></span>" +
+      "<span><a href='#' class='os-link mac-link'>Mac</a></span>" +
+      "<span><a href='#' class='os-link nix-link'>Linux</a></span>" +
       "</span>" +
-    "</span>"
+      "</span>",
   );
 
-  switcher.find(".win-link").click(function(event) {
+  switcher.find(".win-link").click(function (event) {
     event.preventDefault();
     saveOs("win");
 
@@ -54,7 +122,7 @@ function initializeOsSwitchers() {
     $(".os-specific .win-link").addClass("active");
     $(".os-specific").children("div").hide().filter(".win").show();
   });
-  switcher.find(".mac-link").click(function(event) {
+  switcher.find(".mac-link").click(function (event) {
     event.preventDefault();
     saveOs("mac");
 
@@ -62,7 +130,7 @@ function initializeOsSwitchers() {
     $(".os-specific .mac-link").addClass("active");
     $(".os-specific").children("div").hide().filter(".mac").show();
   });
-  switcher.find(".nix-link").click(function(event) {
+  switcher.find(".nix-link").click(function (event) {
     event.preventDefault();
     saveOs("nix");
 
@@ -72,7 +140,8 @@ function initializeOsSwitchers() {
   });
 }
 
-$(document).ready(function() {
+$(document).ready(function () {
+  initializeThemeToggle();
   addIcons();
   initializeOsSwitchers();
   loadOs();
@@ -91,7 +160,7 @@ $(document).ready(function() {
         osLabel = "Linux";
         break;
       default:
-        osLabel = "Error: Unknown Operating System"
+        osLabel = "Error: Unknown Operating System";
     }
     osLabelElement.text(osLabel);
   }
@@ -105,7 +174,7 @@ function topFunction() {
   });
 }
 
-window.addEventListener("scroll", function() {
+window.addEventListener("scroll", function () {
   if (window.scrollY > 100) {
     $(".go-to-top-arrow").addClass("active");
   } else {

--- a/js/guides.js
+++ b/js/guides.js
@@ -1,12 +1,12 @@
 function saveOs(os) {
-  Cookies.set("os", os, { expires: 1825, path: "/" }); // expires in 5 years
+  Cookies.set("os", os, { expires: 1825, path: '/' }); // expires in 5 years
 }
 
 function getPreferredTheme() {
   return window.matchMedia &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
 }
 
 function getStoredTheme() {
@@ -19,7 +19,7 @@ function getStoredTheme() {
 
 function getTheme() {
   var storedTheme = getStoredTheme();
-  if (storedTheme === "light" || storedTheme === "dark") {
+  if (storedTheme === 'light' || storedTheme === 'dark') {
     return storedTheme;
   }
 
@@ -33,43 +33,43 @@ function saveTheme(theme) {
 }
 
 function updateThemeToggleLabels(theme) {
-  var nextTheme = theme === "dark" ? "light" : "dark";
-  var ariaLabel = "Switch to " + nextTheme + " theme";
-  var buttonLabel = nextTheme === "dark" ? "Dark Mode" : "Light Mode";
+  var nextTheme = theme === 'dark' ? 'light' : 'dark';
+  var ariaLabel = 'Switch to ' + nextTheme + ' theme';
+  var buttonLabel = nextTheme === 'dark' ? 'Dark Mode' : 'Light Mode';
 
-  $("[data-theme-toggle]").text(buttonLabel).attr("aria-label", ariaLabel);
+  $('[data-theme-toggle]').text(buttonLabel).attr('aria-label', ariaLabel);
 }
 
 function applyTheme(theme) {
-  document.documentElement.setAttribute("data-theme", theme);
+  document.documentElement.setAttribute('data-theme', theme);
   updateThemeToggleLabels(theme);
 }
 
 function initializeThemeToggle() {
   applyTheme(getTheme());
 
-  $("[data-theme-toggle]").click(function () {
+  $('[data-theme-toggle]').click(function() {
     var nextTheme =
-      document.documentElement.getAttribute("data-theme") === "dark"
-        ? "light"
-        : "dark";
+      document.documentElement.getAttribute('data-theme') === 'dark'
+        ? 'light'
+        : 'dark';
     saveTheme(nextTheme);
     applyTheme(nextTheme);
   });
 }
 
 function loadOs() {
-  var osFromCookie = Cookies.get("os");
+  var osFromCookie = Cookies.get('os');
   if (osFromCookie) {
-    $(".os-specific")
-      .find("." + osFromCookie + "-link")
+    $('.os-specific')
+      .find('.' + osFromCookie + '-link')
       .click();
   } else if (detectOs()) {
-    $(".os-specific")
-      .find("." + detectOs() + "-link")
+    $('.os-specific')
+      .find('.' + detectOs() + '-link')
       .click();
   } else {
-    $(".os-specific").find(".win-link").click();
+    $('.os-specific').find('.win-link').click();
   }
 }
 
@@ -77,11 +77,11 @@ function detectOs() {
   try {
     var browserVersion = navigator.appVersion;
     if (browserVersion.match(/Win/i)) {
-      return "win";
+      return 'win';
     } else if (browserVersion.match(/Macintosh/i)) {
-      return "mac";
+      return 'mac';
     } else {
-      return "nix";
+      return 'nix';
     }
   } catch (e) {
     return false;
@@ -89,21 +89,19 @@ function detectOs() {
 }
 
 function addIcons() {
-  $("code.language-sh, code.language-bat")
-    .closest(".highlight")
+  $('code.language-sh, code.language-bat')
+    .closest('.highlight')
     .before('<i class="icon-small-prompt"></i>');
-  $(
-    "code.language-erb, code.language-html, code.language-ruby, code.language-css",
-  )
-    .closest(".highlight")
+  $('code.language-erb, code.language-html, code.language-ruby, code.language-css')
+    .closest('.highlight')
     .before('<i class="icon-small-text-editor"></i>');
-  $("code.language-browser")
-    .closest(".highlight")
+  $('code.language-browser')
+    .closest('.highlight')
     .before('<i class="icon-small-browser"></i>');
 }
 
 function initializeOsSwitchers() {
-  var osInstructions = $(".os-specific");
+  var osInstructions = $('.os-specific');
   var switcher = osInstructions.prepend(
     "<span class='picker'><span class='picker-label'>Choose your Operating System:</span> " +
       "<span class='picker-options'>" +
@@ -111,12 +109,12 @@ function initializeOsSwitchers() {
       "<span><a href='#' class='os-link mac-link'>Mac</a></span>" +
       "<span><a href='#' class='os-link nix-link'>Linux</a></span>" +
       "</span>" +
-      "</span>",
+      "</span>"
   );
 
-  switcher.find(".win-link").click(function (event) {
+  switcher.find('.win-link').click(function(event) {
     event.preventDefault();
-    saveOs("win");
+    saveOs('win');
 
     $(".os-specific .os-link").removeClass("active");
     $(".os-specific .win-link").addClass("active");

--- a/js/guides.js
+++ b/js/guides.js
@@ -3,23 +3,24 @@ function saveOs(os) {
 }
 
 function getPreferredTheme() {
-  return window.matchMedia &&
-    window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
-    : 'light';
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  } else {
+    return "light";
+  }
 }
 
 function getStoredTheme() {
   try {
     return localStorage.getItem("theme");
-  } catch (error) {
+  } catch(e) {
     return null;
   }
 }
 
 function getTheme() {
   var storedTheme = getStoredTheme();
-  if (storedTheme === 'light' || storedTheme === 'dark') {
+  if (storedTheme === "light" || storedTheme === "dark") {
     return storedTheme;
   }
 
@@ -29,46 +30,40 @@ function getTheme() {
 function saveTheme(theme) {
   try {
     localStorage.setItem("theme", theme);
-  } catch (error) {}
+  } catch(e) {}
 }
 
 function updateThemeToggleLabels(theme) {
-  var nextTheme = theme === 'dark' ? 'light' : 'dark';
-  var ariaLabel = 'Switch to ' + nextTheme + ' theme';
-  var buttonLabel = nextTheme === 'dark' ? 'Dark Mode' : 'Light Mode';
+  var nextTheme = theme === "dark" ? "light" : "dark";
+  var ariaLabel = "Switch to " + nextTheme + " theme";
+  var buttonLabel = nextTheme === "dark" ? "Dark Mode" : "Light Mode";
 
-  $('[data-theme-toggle]').text(buttonLabel).attr('aria-label', ariaLabel);
+  $("[data-theme-toggle]").text(buttonLabel).attr("aria-label", ariaLabel);
 }
 
 function applyTheme(theme) {
-  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.setAttribute("data-theme", theme);
   updateThemeToggleLabels(theme);
 }
 
 function initializeThemeToggle() {
   applyTheme(getTheme());
 
-  $('[data-theme-toggle]').click(function() {
-    var nextTheme = document.documentElement.getAttribute('data-theme') === 'dark' ?
-      'light' :
-      'dark';
+  $("[data-theme-toggle]").click(function() {
+    var nextTheme = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
     saveTheme(nextTheme);
     applyTheme(nextTheme);
   });
 }
 
 function loadOs() {
-  var osFromCookie = Cookies.get('os');
-  if (osFromCookie) {
-    $('.os-specific')
-      .find('.' + osFromCookie + '-link')
-      .click();
-  } else if (detectOs()) {
-    $('.os-specific')
-      .find('.' + detectOs() + '-link')
-      .click();
+  var osFromCookie = Cookies.get("os");
+  if(osFromCookie) {
+    $(".os-specific").find("." + osFromCookie + "-link").click();
+  } else if(detectOs()) {
+    $(".os-specific").find("." + detectOs() + "-link").click();
   } else {
-    $('.os-specific').find('.win-link').click();
+    $(".os-specific").find(".win-link").click();
   }
 }
 
@@ -76,50 +71,44 @@ function detectOs() {
   try {
     var browserVersion = navigator.appVersion;
     if (browserVersion.match(/Win/i)) {
-      return 'win';
+      return "win";
     } else if (browserVersion.match(/Macintosh/i)) {
-      return 'mac';
+      return "mac";
     } else {
-      return 'nix';
+      return "nix";
     }
-  } catch (e) {
+  } catch(e) {
     return false;
   }
 }
 
 function addIcons() {
-  $('code.language-sh, code.language-bat')
-    .closest('.highlight')
-    .before('<i class="icon-small-prompt"></i>');
-  $('code.language-erb, code.language-html, code.language-ruby, code.language-css')
-    .closest('.highlight')
-    .before('<i class="icon-small-text-editor"></i>');
-  $('code.language-browser')
-    .closest('.highlight')
-    .before('<i class="icon-small-browser"></i>');
+  $("code.language-sh, code.language-bat").closest('.highlight').before('<i class="icon-small-prompt"></i>');
+  $("code.language-erb, code.language-html, code.language-ruby, code.language-css").closest('.highlight').before('<i class="icon-small-text-editor"></i>');
+  $("code.language-browser").closest('.highlight').before('<i class="icon-small-browser"></i>');
 }
 
 function initializeOsSwitchers() {
-  var osInstructions = $('.os-specific');
+  var osInstructions = $(".os-specific");
   var switcher = osInstructions.prepend(
     "<span class='picker'><span class='picker-label'>Choose your Operating System:</span> " +
       "<span class='picker-options'>" +
-      "<span><a href='#' class='os-link win-link'>Windows</a></span>" +
-      "<span><a href='#' class='os-link mac-link'>Mac</a></span>" +
-      "<span><a href='#' class='os-link nix-link'>Linux</a></span>" +
+        "<span><a href='#' class='os-link win-link'>Windows</a></span>" +
+        "<span><a href='#' class='os-link mac-link'>Mac</a></span>" +
+        "<span><a href='#' class='os-link nix-link'>Linux</a></span>" +
       "</span>" +
-      "</span>"
+    "</span>"
   );
 
-  switcher.find('.win-link').click(function(event) {
+  switcher.find(".win-link").click(function(event) {
     event.preventDefault();
-    saveOs('win');
+    saveOs("win");
 
     $(".os-specific .os-link").removeClass("active");
     $(".os-specific .win-link").addClass("active");
     $(".os-specific").children("div").hide().filter(".win").show();
   });
-  switcher.find(".mac-link").click(function (event) {
+  switcher.find(".mac-link").click(function(event) {
     event.preventDefault();
     saveOs("mac");
 
@@ -127,7 +116,7 @@ function initializeOsSwitchers() {
     $(".os-specific .mac-link").addClass("active");
     $(".os-specific").children("div").hide().filter(".mac").show();
   });
-  switcher.find(".nix-link").click(function (event) {
+  switcher.find(".nix-link").click(function(event) {
     event.preventDefault();
     saveOs("nix");
 
@@ -137,7 +126,7 @@ function initializeOsSwitchers() {
   });
 }
 
-$(document).ready(function () {
+$(document).ready(function() {
   initializeThemeToggle();
   addIcons();
   initializeOsSwitchers();
@@ -157,7 +146,7 @@ $(document).ready(function () {
         osLabel = "Linux";
         break;
       default:
-        osLabel = "Error: Unknown Operating System";
+        osLabel = "Error: Unknown Operating System"
     }
     osLabelElement.text(osLabel);
   }
@@ -171,7 +160,7 @@ function topFunction() {
   });
 }
 
-window.addEventListener("scroll", function () {
+window.addEventListener("scroll", function() {
   if (window.scrollY > 100) {
     $(".go-to-top-arrow").addClass("active");
   } else {

--- a/js/guides.js
+++ b/js/guides.js
@@ -2,31 +2,6 @@ function saveOs(os) {
   Cookies.set("os", os, { expires: 1825, path: '/' }); // expires in 5 years
 }
 
-function getPreferredTheme() {
-  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-    return "dark";
-  } else {
-    return "light";
-  }
-}
-
-function getStoredTheme() {
-  try {
-    return localStorage.getItem("theme");
-  } catch(e) {
-    return null;
-  }
-}
-
-function getTheme() {
-  var storedTheme = getStoredTheme();
-  if (storedTheme === "light" || storedTheme === "dark") {
-    return storedTheme;
-  }
-
-  return getPreferredTheme();
-}
-
 function saveTheme(theme) {
   try {
     localStorage.setItem("theme", theme);
@@ -47,7 +22,7 @@ function applyTheme(theme) {
 }
 
 function initializeThemeToggle() {
-  applyTheme(getTheme());
+  updateThemeToggleLabels(document.documentElement.getAttribute("data-theme"));
 
   $("[data-theme-toggle]").click(function() {
     var nextTheme = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";

--- a/js/guides.js
+++ b/js/guides.js
@@ -9,11 +9,7 @@ function saveTheme(theme) {
 }
 
 function updateThemeToggleLabels(theme) {
-  var nextTheme = theme === "dark" ? "light" : "dark";
-  var ariaLabel = "Switch to " + nextTheme + " theme";
-  var buttonLabel = nextTheme === "dark" ? "Dark Mode" : "Light Mode";
-
-  $("[data-theme-toggle]").text(buttonLabel).attr("aria-label", ariaLabel);
+  $("[data-theme-toggle]").text(theme === "dark" ? "Light Mode" : "Dark Mode");
 }
 
 function applyTheme(theme) {


### PR DESCRIPTION
## Summary

Adds a site-wide light/dark theme toggle to the guides navbar and applies theme-aware styling across the shared layout. The selected theme is persisted between page loads, and the toggle remains accessible with a keyboard-only focus state.

## What Changed

- Added a theme toggle to the shared navbar for desktop and mobile layouts  
- Persisted the selected theme with `localStorage`  
- Applied the theme before page render to avoid flash on navigation  
- Introduced shared CSS variables for light and dark themes  

### Updated shared UI surfaces for both themes:

- Page background  
- Header and footer  
- Links and borders  
- Guide cards and notices  
- Keyboard shortcut styling  
- Scroll-to-top button  
- Syntax-highlighted code blocks  

- Refined the toggle focus treatment to use a cleaner `:focus-visible` style instead of a heavy dashed outline after mouse clicks

## Files

- `_layouts/default.html:1`  
- `_includes/header.html:1`  
- `js/guides.js:1`  
- `css/style.css:1`  
- `css/code.css:1`  

## Notes

- The toggle currently uses text labels: **Dark mode / Light mode**  
- The initial theme falls back to the user’s OS preference if no saved choice exists  

## Screenshot

<img width="1306" height="700" alt="dark-mode-screenshot" src="https://github.com/user-attachments/assets/0e97c759-ac3e-472a-ac47-19e0a1be929a" />

---

Closes #603