### PR TITLE
Use main as the branch name in git push instructions

### DIFF
--- a/_pages/continuous-codeship.md
+++ b/_pages/continuous-codeship.md
@@ -34,7 +34,7 @@ Now let's finish your setup and go to the dashboard. You can trigger a so-called
 {% highlight sh %}
 git add .
 git commit -m "test Codeship integration"
-git push origin master
+git push origin main
 {% endhighlight %}
 
 You can access the build details by clicking the arrow on the right. Here you can follow the build while it's still running. Better than reality tv - promised. 

--- a/_pages/continuous-snap-ci.md
+++ b/_pages/continuous-snap-ci.md
@@ -41,7 +41,7 @@ In case you have any test failures however, you can fix those and push the chang
 {% highlight sh %}
 git add .
 git commit -m "fix tests"
-git push origin master
+git push origin main
 {% endhighlight %}
 
 Snap CI will automatically detect the changes from GitHub and run a new instance of the pipeline. At this point you've already started testing your code.

--- a/_pages/continuous-travis.md
+++ b/_pages/continuous-travis.md
@@ -51,7 +51,7 @@ Commit and push a code change to your repository and check travis-ci.org to see 
 {% highlight sh %}
 git add .
 git commit -m "test Travis integration"
-git push origin master
+git push origin main
 {% endhighlight %}
 
 Now we can configure the actual deployment.

--- a/_pages/deployment/heroku.md
+++ b/_pages/deployment/heroku.md
@@ -89,7 +89,7 @@ In this case "young-reaches-87845" is your app name.
 
 ### Pushing the code
 
-Next we need to push our code to heroku by typing `git push heroku master`.
+Next we need to push our code to heroku by typing `git push heroku main`.
 You'll see push output like the following:
 
 {% highlight sh %}
@@ -117,7 +117,7 @@ remote:        https://young-reaches-87845.herokuapp.com/ deployed to Heroku
 remote:
 remote: Verifying deploy... done.
 To https://git.heroku.com/young-reaches-87845.git
- * [new branch]      master -> master
+ * [new branch]      main -> main
 {% endhighlight %}
 
 You'll know the app is done being pushed, when you see the "Launching..." text like above.

--- a/_pages/github.md
+++ b/_pages/github.md
@@ -135,10 +135,10 @@ Copy and save the PAT token, ideally in a secure password manager. Be careful no
 Now we want to _push_ the local changes in the Git repository to the repository on GitHub with the following command in your terminal.
 
 {% highlight sh %}
-git push -u origin master
+git push -u origin main
 {% endhighlight %}
 
-_Your app's branch name may be different, like `main`. Change the "master" argument to the branch name listed in `git branch`. Your current branch is indicated with the `*` symbol at the start of the line._
+_Your app's branch name may be different, like `master` for apps created with older versions of Rails. Change the "main" argument to the branch name listed in `git branch`. Your current branch is indicated with the `*` symbol at the start of the line._
 
 When the authentication prompt appears in your terminal, use your PAT as the password, example below. Note that when you paste your PAT in the password, it will not show. Don't paste again, or you will be entering the token twice.
 
@@ -180,10 +180,10 @@ Talk about what makes a good commit message (active, descriptive and short).
 And push the changes to GitHub:
 
 {% highlight sh %}
-git push origin master
+git push origin main
 {% endhighlight %}
 
-_Your app's branch name may be different, like `main`. Change the "master" argument to the branch name listed in `git branch`. Your current branch is indicated with the `*` symbol at the start of the line._
+_Your app's branch name may be different, like `master` for apps created with older versions of Rails. Change the "main" argument to the branch name listed in `git branch`. Your current branch is indicated with the `*` symbol at the start of the line._
 
 ## What's next?
 

--- a/_pages/touristic-autism_git.md
+++ b/_pages/touristic-autism_git.md
@@ -79,7 +79,7 @@ Push up your local changes to the remote repository as follows:
   <div class="mac nix">
     {% highlight sh %}
 $ git remote add origin https://github.com/<username>/railsgirls-galway-2014.git
-$ git push -u origin master
+$ git push -u origin main
   {% endhighlight %}
   </div>
 The result is a page at GitHub (for instance, [here's mine](https://github.com/iammyr/railsgirls-galway-2014)) for our application repository, which provides nice rendering, sharing functionalities and statistics: take a look by yourself at https://github.com/<your username>/railsgirls-galway-2014

--- a/_pages/touristic-autism_static-pages-tdd.md
+++ b/_pages/touristic-autism_static-pages-tdd.md
@@ -206,7 +206,7 @@ From this point Pry has access to the local scope. You can type "exit" to exit P
 
 ##Continuous Integration (CI) with Travis-CI
 
-The principle of CI is to commit/push early and often to avoid conflicts between your code and the master branch. When you do (in this case we're committing to GitHub) then that should kick off a 'build' on your CI server which runs the relevant tests to ensure all is working as it should be.
+The principle of CI is to commit/push early and often to avoid conflicts between your code and the main branch. When you do (in this case we're committing to GitHub) then that should kick off a 'build' on your CI server which runs the relevant tests to ensure all is working as it should be.
 
 Travis CI is a hosted continuous integration service for the open source community. It offers free CI services for open-source projects and also has a paid model for businesses. We'll be using the free open-source model on our GitHub repository.
 
@@ -232,7 +232,7 @@ bundler_args: --without development
 
 branches:
   only:
-    - master
+    - main
 
 notifications:
   email:


### PR DESCRIPTION
Rails 8 initializes new apps with a `main` default branch, so `git push -u origin master` in the GitHub guide fails for current workshop attendees. This updates the push commands in the GitHub, Heroku, and CI guides to use `main`, and flips the note in the GitHub guide to mention `master` as the legacy case instead.

Links to `master` branches of external repositories and pushes to the retired OpenShift v2 platform, which only deployed the `master` branch, are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
