### PR TITLE
Consolidate duplicate intro paragraph in touristic-autism guides

### DIFF
--- a/_includes/touristic-autism-intro.md
+++ b/_includes/touristic-autism-intro.md
@@ -1,0 +1,1 @@
+The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).

--- a/_pages/touristic-autism_basic-app.md
+++ b/_pages/touristic-autism_basic-app.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_basic-app
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 <h3>GitHub</h3>
 [Slides - by Kevin Lyda @]()

--- a/_pages/touristic-autism_continuous-deployment.md
+++ b/_pages/touristic-autism_continuous-deployment.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_continuous-deployment
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](http://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 
 

--- a/_pages/touristic-autism_design.md
+++ b/_pages/touristic-autism_design.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_design
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 {% coach %}
 Talk about the relationship between HTML and Rails. What part of views is HTML and what is Embedded Ruby (ERB)? What is MVC and how does this relate to it? (Models and controllers are responsible for generating the HTML views.)

--- a/_pages/touristic-autism_git.md
+++ b/_pages/touristic-autism_git.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_git
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 
 Navigate to the root directory of the first app and initialize a new repository:

--- a/_pages/touristic-autism_google-map.md
+++ b/_pages/touristic-autism_google-map.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_google-map
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 
 We need to install a piece of software to let us display and interact with Google Maps.

--- a/_pages/touristic-autism_image-upload.md
+++ b/_pages/touristic-autism_image-upload.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_image-upload
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 
 We need to install a piece of software to let us upload files in Rails.

--- a/_pages/touristic-autism_intro.md
+++ b/_pages/touristic-autism_intro.md
@@ -18,7 +18,7 @@ The extension comprises of the following **new features**:
 * Resource Rating
 * Authenticated User (via devise) permission setting
 
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 
 

--- a/_pages/touristic-autism_resource-modeling.md
+++ b/_pages/touristic-autism_resource-modeling.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_resource-modeling
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 What do we want our app to do? As a first thing, we would like to
 * authenticate **users**

--- a/_pages/touristic-autism_resource-rating.md
+++ b/_pages/touristic-autism_resource-rating.md
@@ -8,7 +8,7 @@ permalink: touristic-autism_resource-rating
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic Rails Girls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift) and [adding comments](/commenting).
+{% include touristic-autism-intro.md %}
 
 What do we want our app to do? As a first thing, we would like to 
 * authenticate **users**

--- a/_pages/touristic-autism_static-pages-tdd.md
+++ b/_pages/touristic-autism_static-pages-tdd.md
@@ -8,7 +8,8 @@ permalink: touristic-autism_static-pages-tdd
 
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
-The basic guides that have been merged and adapted are the [Ruby on Rails Tutorial](https://www.railstutorial.org/book), the [basic RailsGirls app](/app) and the tutorials for [creating thumbnails](/thumbnails), [authenticating users](/devise), [adding design](/design), [deploying to OpenShift](/deployment/openshift), [adding comments](/commenting) and [Mark McDonnell's tutorial](https://code.tutsplus.com/tutorials/testing-your-ruby-code-with-guard-rspec-pry--cms-19974).
+{% include touristic-autism-intro.md %}
+This guide also adapts [Mark McDonnell's tutorial](https://code.tutsplus.com/tutorials/testing-your-ruby-code-with-guard-rspec-pry--cms-19974).
 
 Rails includes a default Test::Unit framework used to test your code. We will use a more advanced testing framework called RSpec to write a thorough test suite. We need to be able to write tests that are fast and give us instant feedback on problems with our code. 
 


### PR DESCRIPTION
The paragraph listing the merged base guides was repeated in all 10 `touristic-autism_*.md` pages. This extracts it into `_includes/touristic-autism-intro.md` and replaces each copy with an include tag, so future edits happen in one place.

The copies had drifted slightly. The include normalizes the Rails Tutorial link to `https` and the RailsGirls spelling. `touristic-autism_static-pages-tdd.md` additionally referenced Mark McDonnell's tutorial, so that page keeps a separate sentence for it after the include. Verified with `bundle exec jekyll build` that each page renders the paragraph once.

Fixes #669
