### PR TITLE
Use Active Storage for picture uploads instead of CarrierWave

### DIFF
--- a/_pages/app.md
+++ b/_pages/app.md
@@ -149,7 +149,7 @@ Next you're going to use Rails' scaffold functionality to generate a starting po
 Run the following command in the Terminal app:
 
 {% highlight sh %}
-rails generate scaffold idea name:string description:text picture:string
+rails generate scaffold idea name:string description:text
 {% endhighlight %}
 
 {% coach %}

--- a/_pages/deployment/heroku.md
+++ b/_pages/deployment/heroku.md
@@ -153,7 +153,7 @@ if it restarts (for example, when you push a new version).
 
 In the [App](/app) tutorial the ability to attach a file to the Idea record is
 added, which results in new files being written to your applications
-`public/uploads` folder. The ephemeral storage in Heroku can be seen with the
+`storage` folder. The ephemeral storage in Heroku can be seen with the
 following steps:
 
 1. Launch the app with `heroku open`
@@ -177,7 +177,7 @@ could potentially be hosted anywhere) which your application can use as persiste
 While this functionality is a bit out of scope for this tutorial there are some
 resources available which you can use to find your way:
 
-* [How to: Make Carrierwave work on Heroku](https://github.com/carrierwaveuploader/carrierwave/wiki/How-to%3A-Make-Carrierwave-work-on-Heroku)
+* [Active Storage Overview: cloud storage services](https://guides.rubyonrails.org/active_storage_overview.html#setup)
 * [Amazon S3 – The Beginner’s Guide](https://www.hongkiat.com/blog/amazon-s3-the-beginners-guide/)
 
 As always if you require any more information or assistance your coaches will be able to assist.

--- a/_pages/design.md
+++ b/_pages/design.md
@@ -41,7 +41,7 @@ Open `app/views/ideas/_idea.html.erb` in your Text Editor and replace all the li
     <p><%= idea.description %></p>
     <small class="opacity-50 text-nowrap">Last updated <%= time_ago_in_words idea.updated_at %></small>
   </div>
-  <%= image_tag(idea.picture_url, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture? %>
+  <%= image_tag(idea.picture, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture.attached? %>
 </div>
 {% endhighlight %}
 
@@ -68,7 +68,7 @@ Open `app/views/ideas/show.html.erb` in your text editor and replace all lines w
     <p><%= @idea.description %></p>
     <small class="opacity-50 text-nowrap">Last updated <%= time_ago_in_words @idea.updated_at %></small>
   </div>
-  <%= image_tag(@idea.picture_url, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if @idea.picture? %>
+  <%= image_tag(@idea.picture, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if @idea.picture.attached? %>
 </div>
 
 <div class="d-flex gap-3 py-3">

--- a/_pages/guide-to-the-guide.md
+++ b/_pages/guide-to-the-guide.md
@@ -52,14 +52,14 @@ Rails scaffolding is a command (`rails generate scaffold`) for introducing a new
 In Rails, a model represents a definition of a resource in your application, and how it should interact with other parts of the application. Depending on the nature of the website, these resources could be users, posts, groups etc. When a model is generated, a corresponding *database table* is created. This database table contains information that represents specified attributes of the model, e.g. for a User model, there might be a ‘name’ column and an ‘email’ column, and there will be rows for each subsequent user created. In the application you are creating, these resources are ideas and the model is ‘Idea’.
 
 {% highlight rb %}
-rails generate scaffold idea name:string description:text picture:string
+rails generate scaffold idea name:string description:text
 {% endhighlight %}
 
-In order to create our idea model, we use the `scaffold` command which includes an argument with the singular version of the model name (`idea`), and an argument with parameters (specifications) for the model’s attributes. This means that the `idea` model corresponds to a table in the database with columns for the attributes specified in the command: `name`, `description` and `picture`. The `scaffold` command also auto-generates an `id` attribute, referred to as the `primary key`, which is used to establish relationships between database tables.
+In order to create our idea model, we use the `scaffold` command which includes an argument with the singular version of the model name (`idea`), and an argument with parameters (specifications) for the model’s attributes. This means that the `idea` model corresponds to a table in the database with columns for the attributes specified in the command: `name` and `description`. The `scaffold` command also auto-generates an `id` attribute, referred to as the `primary key`, which is used to establish relationships between database tables.
 
 - `rails generate scaffold` - this calls the scaffold command.
 - `idea` - this tells the scaffold command what we want to call our model.
-- `name:string description:text picture:string` - provides a list of attributes we want our model (and the database table that goes with it) to have. The `string` and `text` parts of the argument determine the nature of each attribute, i.e. each description needs to be ‘text’, and not, for example, an ‘integer’ (or any other type of information).
+- `name:string description:text` - provides a list of attributes we want our model (and the database table that goes with it) to have. The `string` and `text` parts of the argument determine the nature of each attribute, i.e. each description needs to be ‘text’, and not, for example, an ‘integer’ (or any other type of information).
 
 ### The ideas table
 
@@ -69,7 +69,6 @@ In order to create our idea model, we use the `scaffold` command which includes 
 			<th>id</th>
 			<th>name</th>
 			<th>description</th>
-			<th>picture</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -77,17 +76,14 @@ In order to create our idea model, we use the `scaffold` command which includes 
 			<td>1</td>
 			<td>“Money-spinner”</td>
 			<td>“Open a moveable shop!”</td>
-			<td>“GreatIdea.jpg”</td>
 		</tr>
 		<tr>
 			<td>2</td>
 			<td>“Champagne For Breakfast!”</td>
 			<td>“We should do this every Friday!”</td>
-			<td>“Champagne.jpg”</td>
 		</tr>
 		<tr>
 			<td>3</td>
-			<td>...</td>
 			<td>...</td>
 			<td>...</td>
 		</tr>
@@ -283,10 +279,14 @@ In this code:
 
 In the [Add picture uploads](/uploads) we'll add a way to uploads pictures to ideas.
 
+### Active Storage
+
+Rails comes with a built-in feature for file uploads called *Active Storage*. It stores the uploaded files and uses two extra database tables to link the files to records, like the ideas in your application. This is why we run the `rails active_storage:install` and `rails db:migrate` commands before using it. The `has_one_attached :picture` line in the Idea model tells Rails that every idea can have one attached file, named `picture`.
+
 ### Libraries
 Many programming languages, including Ruby, use a wide range of libraries. In Ruby’s case, most of these libraries are released in the form of self-contained packages called *gems*, which contain all the information required to install and implement them. These gems are contained in your application’s `Gemfile` and if you look in this file you’ll notice that when you created your first Rails application it came with several gems that ensure your application functions correctly.
 
-Gems help simplify and prevent repetition in a developer’s code, in keeping with the DRY (Don’t Repeat Yourself) principle of software development. Gems may solve specific problems, add specific functionality, or address specific requirements, meaning that should another developer encounter a similar scenario, instead of writing new code, they can install a gem containing pre-written code. For example, “CarrierWave”, the gem you are adding to your gemfile is designed to make it easy to upload files to your application.
+Gems help simplify and prevent repetition in a developer’s code, in keeping with the DRY (Don’t Repeat Yourself) principle of software development. Gems may solve specific problems, add specific functionality, or address specific requirements, meaning that should another developer encounter a similar scenario, instead of writing new code, they can install a gem containing pre-written code. For example, “image_processing”, the gem you add in the [Create picture thumbnails](/thumbnails) guide, is designed to make it easy to resize images in your application.
 
 “Bundler” is the software Ruby uses to track and manage gems. The `bundle install` command runs Bundler and installs the gems specified in your Gemfile. You’ll notice the code `source "https://rubygems.org"` at the top of your Gemfile. Whenever you add a gem to your gemfile and run the `bundle install` command, this code tells your application to fetch the gem from <https://rubygems.org>. “RubyGems” is a Ruby-specific packaging system, the purpose of which is to simplify the creation, sharing and installation of gems.
 
@@ -300,10 +300,10 @@ The file `app/views/ideas/_form.html.erb` contains HTML code that determines the
 
 If you take a look in the `_form.html.erb` file, you will see the code `form_for` in the first line of code. This is a block used to create an HTML form. Using this block, we can access methods to put different input fields in the form.
 
-The code we are implementing, `<%= f.file_field :picture %>`, tells Rails to create a file input on the form and map the submitted information to the ‘picture’ attribute of an ‘idea’ in our ideas database table. We changed the code from `<%= f.text_field :picture %>` to `<%= f.file_field :picture %>` because `file_field` makes it easier for the user to select the image they wish to upload.
+The code we are implementing, `<%= form.file_field :picture %>`, tells Rails to create a file input on the form and attach the submitted file to the ‘picture’ attachment of an ‘idea’. We use `file_field` instead of `text_field` because `file_field` makes it easier for the user to select the image they wish to upload.
 
 In the code `<%= @idea.picture %>`, `@idea` is known as an *instance variable*. Instance variables are prefixed with an @ symbol and are defined in the controller action that corresponds with the view in which they are referenced. For the purposes of the code we are implementing, `@idea` is defined in the ‘show’ action of the `Ideas` controller, with the code `@idea = Idea.find(params[:id])`. This makes it available for us to use in the view `show.html.erb`. It could be defined differently in different controller actions (e.g. index or new). The code `@idea = Idea.find(params[:id])` uses the Rails `find` method to retrieve specific ideas from the database.
 
-The code that follows the `@idea` variable (`.picture`) tells Rails to access the ‘picture’ attribute of our resource (idea). By replacing the code  `<%= @idea.picture %>` with `<%= image_tag(@idea.picture_url...)` we are using the Ruby `image_tag` *helper* which translates to an HTML `<img>` tag (used to define images in HTML) but by default retrieves images from the folder public/images, which is where our uploaded images are stored. The `image_tag` helper also allows us to insert a block of code which creates a path to an image associated with a particular idea (`@idea.picture_url`).
+The code that follows the `@idea` variable (`.picture`) tells Rails to access the ‘picture’ attachment of our resource (idea). In the code `<%= image_tag(@idea.picture...)` we are using the Ruby `image_tag` *helper* which translates to an HTML `<img>` tag (used to define images in HTML). Given the picture attachment, the `image_tag` helper creates a path to the image associated with a particular idea.
 
-You will notice that within this block of code you are implementing we are also able to set a default width for each image (`:width => 600`). The final line of code `if @idea.picture?` tells Rails to check the corresponding database table to see whether a picture exists before rendering the code underneath.
+You will notice that within this block of code you are implementing we are also able to set a default width for each image (`width: 600`). The final part of the code, `if @idea.picture.attached?`, tells Rails to check whether a picture is attached to the idea before rendering the image tag.

--- a/_pages/thumbnails.md
+++ b/_pages/thumbnails.md
@@ -42,21 +42,23 @@ sudo apt-get install -y imagemagick
 Explain what is ImageMagick and how is it different from libraries/gems we used before?
 {% endcoach %}
 
-## Install a Ruby gem for ImageMagick
+## Install a Ruby gem for image resizing
 
-For Ruby to talk with ImageMagick, we'll be using the `mini_magick` Ruby gem. First we will need to add it to our app and install it.
+For Ruby to talk with ImageMagick, we'll be using the `image_processing` Ruby gem. A Ruby gem is a piece of software we can install in the app.
 
-Open `Gemfile` in your Text Editor and add this line:
-
-{% highlight ruby %}
-gem "mini_magick"
-{% endhighlight %}
-
-below the line:
+Open `Gemfile` in your Text Editor and find this line:
 
 {% highlight ruby %}
-gem "carrierwave"
+# gem "image_processing", "~> 1.2"
 {% endhighlight %}
+
+Remove the `#` sign at the front of the line and save the file. If the line is not in your `Gemfile`, add it without the `#` sign instead.
+
+{% coach %}
+Explain the concept of comments in code. Explain what libraries (Ruby gems) are and why they are useful. Describe what Open Source software is.
+
+Resources: RubyGems GitHub [introduction](https://github.com/rubygems/rubygems#rubygems-) and Wikipedia [OSS](https://en.wikipedia.org/wiki/Open-source_software)
+{% endcoach %}
 
 In the Terminal app run this command:
 
@@ -64,48 +66,40 @@ In the Terminal app run this command:
 bundle install
 {% endhighlight %}
 
-Make sure to (re)start your Rails server after installation.
+This will install the "image_processing" gem we enabled in the `Gemfile` file.
 
-## Tell your app to create thumbnails
+## Tell your app to use ImageMagick
 
-Now that we have a way to talk to ImageMagick through the `mini_magick` Ruby gem, we can tell the file upload gem `carrierwave` to create thumbnails for every picture you upload.
+By default Rails resizes images with a different tool, called libvips, which may not be available on your computer. Let's tell the app to use the ImageMagick tool we just installed.
 
-Open `app/uploaders/picture_uploader.rb` and find the line that looks like this:
-
-{% highlight ruby %}
-# include CarrierWave::MiniMagick
-{% endhighlight %}
-
-Remove the `#` sign at the front of the line.
-
-{% coach %}
-Explain the concept of comments in code.
-{% endcoach %}
-
-Below the line you just changed, add these lines:
+Open `config/application.rb` in your Text Editor and find the line that looks like this:
 
 {% highlight ruby %}
-version :thumb do
-  process :resize_to_fit => [150, 150]
-end
+class Application < Rails::Application
 {% endhighlight %}
 
-The images uploaded from now on will be resized to a smaller size, but the ones we already have haven't been updated. Instead, let's edit an idea and add a new picture. When saved the idea now has a thumbnail for the uploaded picture.
+Below this line, add this line and save the file:
+
+{% highlight ruby %}
+config.active_storage.variant_processor = :mini_magick
+{% endhighlight %}
+
+Make sure to (re)start your Rails server after changing the configuration.
 
 ## Display the thumbnail
 
-We haven't changed how the idea pictures are displayed, so it should still be showing the original larger image. Let's change the views to display the thumbnail instead.
+Active Storage can create resized versions of the uploaded pictures, called variants. The thumbnail variant is created the first time it is requested, so we only need to ask for it in the view.
 
 Open `app/views/ideas/_idea.html.erb` and change the line:
 
 {% highlight erb %}
-<%= image_tag(idea.picture_url, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture? %>
+<%= image_tag(idea.picture, width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture.attached? %>
 {% endhighlight %}
 
 to this line:
 
 {% highlight erb %}
-<%= image_tag(idea.picture_url(:thumb), width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture? %>
+<%= image_tag(idea.picture.variant(resize_to_limit: [150, 150]), width: 150, height: 150, class: "img-thumbnail flex-shrink-0") if idea.picture.attached? %>
 {% endhighlight %}
 
 Take a look at the [list of ideas](http://localhost:3000/ideas) in the Browser to see if your ideas now have a thumbnail.

--- a/_pages/uploads.md
+++ b/_pages/uploads.md
@@ -11,62 +11,32 @@ permalink: uploads
 
 The ideas we added in the previous guide can benefit from a visual element, like a picture or drawing to spark the imagination. We can attach pictures by adding a file upload to the Idea model.
 
-## Installing a Ruby gem
+## Setting up Active Storage
 
-To let us upload files in Rails app, we'll need to install a piece of software in the app first.
-
-Open the `Gemfile` file in your Text Editor. Below the following line:
-
-{% highlight ruby %}
-gem "sqlite3"
-{% endhighlight %}
-
-add this line to the file and save it:
-
-{% highlight ruby %}
-gem "carrierwave"
-{% endhighlight %}
+Rails comes with a built-in feature to handle file uploads, called Active Storage. Before we can use it, we need to set it up in the app.
 
 Open the Terminal app and press <kbd>Ctrl</kbd>+<kbd>C</kbd> to quit the Rails server.
 
-Then run the following command in the Terminal:
+Then run the following commands in the Terminal:
 
 {% highlight sh %}
-bundle install
+rails active_storage:install
+rails db:migrate
 {% endhighlight %}
 
-This will install the "carrierwave" gem we added to the `Gemfile` file.
+The first command prepares a change to the database, called a migration. The second command updates the database with the tables Active Storage uses to keep track of uploaded files.
 
 {% coach %}
-Explain what libraries (Ruby gems) are and why they are useful. Describe what Open Source software is.
+Explain what Active Storage is and how it stores the uploaded files. What are database migrations and why do we need to run them?
 
-Resources: RubyGems GitHub [introduction](https://github.com/rubygems/rubygems#rubygems-) and Wikipedia [OSS](https://en.wikipedia.org/wiki/Open-source_software)
+Resource: Rails Guides [Active Storage Overview](https://guides.rubyonrails.org/active_storage_overview.html)
 {% endcoach %}
 
-## Generating a picture uploader
+## Attaching the picture to the idea model
 
-We can now generate the code for handling file uploads. In the Terminal run the following command:
+Rails now knows a way to store file uploads in your app. It needs a bit of help to understand where you want to attach these uploads to.
 
-{% highlight sh %}
-rails generate uploader Picture
-{% endhighlight %}
-
-If an error is shown that the uploader cannot be found also add the following line:
-{% highlight ruby %}
-gem "net-ssh"
-{% endhighlight %}
-
-If you added this gem, please run this command in the Terminal app to install the missing gem, and try again:
-
-{% highlight sh %}
-bundle install
-{% endhighlight %}
-
-## Attaching the picture uploader to the idea model
-
-Rails now knows about a way to upload pictures in your app. It needs a bit of help to understand where you want to attach these uploads to.
-
-Open the `app/models/idea.rb` file in your Text Editor. This file is used to store your ideas in the database and fetch the ideas to show them. We'll change it to tell Rails which field is a file upload.
+Open the `app/models/idea.rb` file in your Text Editor. This file is used to store your ideas in the database and fetch the ideas to show them. We'll change it to tell Rails every idea can have a picture.
 
 Under the following line:
 
@@ -77,59 +47,88 @@ class Idea < ApplicationRecord
 add this line and save the file:
 
 {% highlight ruby %}
-mount_uploader :picture, PictureUploader
+has_one_attached :picture
 {% endhighlight %}
 
-This `mount_uploader` line tells the Idea model that the `picture` field is a file upload. It will store information about the file upload on that field to display it later.
+This `has_one_attached` line tells the Idea model that every idea can have one file attached to it, named `picture`. Active Storage will store the file upload and link it to the idea to display it later.
+
+## Adding the picture to the form
+
+Now that your Idea model can have a picture attached, we can change the form to create and edit ideas to select a picture.
+
+Open the `app/views/ideas/_form.html.erb` file in your Text Editor and find these lines near the bottom of the file:
+
+{% highlight erb %}
+  <div>
+    <%= form.submit %>
+  </div>
+{% endhighlight %}
+
+Above these lines, add the following lines and save the file:
+
+{% highlight erb %}
+  <div>
+    <%= form.label :picture, style: "display: block" %>
+    <%= form.file_field :picture %>
+  </div>
+{% endhighlight %}
+
+The `file_field` helper adds a new element to the form: a file chooser, recognizable by either a "Browse..." or "Choose File" button.
+
+## Allowing the picture to be saved
+
+There's one more change we need to make. For safety reasons, Rails only saves the form fields the app explicitly lists as allowed. Our new picture field is not on that list yet, so it would be ignored when the form is submitted.
+
+Open the `app/controllers/ideas_controller.rb` file in your Text Editor and find the following line near the bottom of the file:
+
+{% highlight ruby %}
+params.expect(idea: [ :name, :description ])
+{% endhighlight %}
+
+Change it to this line and save the file:
+
+{% highlight ruby %}
+params.expect(idea: [ :name, :description, :picture ])
+{% endhighlight %}
+
+If your file shows `params.require(:idea).permit(:name, :description)` instead, add `:picture` to the end of that list in the same way.
+
+{% coach %}
+Explain what strong parameters are and why Rails wants apps to list which form fields can be saved.
+{% endcoach %}
 
 ## Uploading pictures
 
-Now that your Idea model knows that the `picture` field is a file upload, we can change the form to create and edit pictures to select a picture.
-
-Open the `app/views/ideas/_form.html.erb` file in your Text Editor and change the following line:
-
-{% highlight erb %}
-<%= form.text_field :picture %>
-{% endhighlight %}
-
-to this line and save it:
-
-{% highlight erb %}
-<%= form.file_field :picture %>
-{% endhighlight %}
-
 Run `rails server`.
 
-In your browser open <http://localhost:3000/ideas/new>.  Your "New idea" form will now show a different element on the page for the "Picture" field. Instead of a text field a file chooser is visible, recognizable by either a "Browse..." or "Choose File" button.
+In your browser open <http://localhost:3000/ideas/new>. Your "New idea" form will now show the new "Picture" field with the file chooser.
 
-Fill in the form to create a new idea, but this time select a picture as well using this new element/button. Any random image you have on your laptop will do, it's just a test.
+Fill in the form to create a new idea, and select a picture using this new element/button. Any random image you have on your laptop will do, it's just a test.
 
 ## Displaying the picture
 
-You've now added a picture to your idea! You can't see it yet after creating the idea, it will only show the filename right now. Let's change it so it shows the picture.
+You've now added a picture to your idea! You can't see it yet after creating the idea, the pages don't show it. Let's change it so it shows the picture.
 
-To show the picture in the page of the idea itself, open the `app/views/ideas/_idea.html.erb` in the Text editor and change the following line:
+Open the `app/views/ideas/_idea.html.erb` file in the Text Editor and find the last line:
 
 {% highlight erb %}
-<%= idea.picture %>
+</div>
 {% endhighlight %}
 
-to this line and save the file:
+Above this line, add the following line and save the file:
 
 {% highlight erb %}
-<%= image_tag(idea.picture_url, width: 600) if idea.picture? %>
+<%= image_tag(idea.picture, width: 600) if idea.picture.attached? %>
 {% endhighlight %}
 
 Using the `image_tag` we have told Rails to display the file upload as an image if it is present on the idea. Ideas without a picture will not show one.
 
 Refresh the Browser. Your uploaded image should now be visible!
 
-## Configure Git to ignore uploads
+## Where are the pictures stored?
 
-By default your app saves all your images locally, which is fine during development, but we don't want to save them with your app source code.
+While developing your app, Active Storage saves the uploaded files in the `storage` folder of your app. Rails already configured Git to ignore this folder, so the uploaded pictures won't be saved with your app source code.
 
-Open the `.gitignore` file add add this line at the bottom:
-
-{% highlight erb %}
-public/uploads/
-{% endhighlight %}
+{% coach %}
+Show the `storage` folder and the entry ignoring it in the `.gitignore` file. Explain why uploads shouldn't be stored in the app source code, and how apps that are online usually store uploads in a cloud storage service instead.
+{% endcoach %}

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@ description: "Learn how to make your first web app with Ruby on Rails! Sign up f
       <span class="guide-icon" data-icon="13"></span>
       <h3>Create picture thumbnails</h3>
     </a>
-    <p>Instructions on resizing your images using CarrierWave.</p>
+    <p>Instructions on resizing your images using Active Storage.</p>
   </li>
 
   <li>


### PR DESCRIPTION
As reported in #588, the guide still recommends the `carrierwave` gem even though Active Storage ships with Rails.

The uploads guide now sets up Active Storage with `rails active_storage:install` and attaches pictures with `has_one_attached`. The app guide drops the unused `picture:string` column from the scaffold because attachments live in Active Storage tables, and the design snippets use `idea.picture` with `attached?`. The thumbnails guide resizes images with Active Storage variants through the `image_processing` gem. It keeps the existing ImageMagick installation steps by setting `config.active_storage.variant_processor = :mini_magick`, so attendees on Windows don't need libvips. The guide-to-the-guide companion, the guides index, and the Heroku deployment notes are updated to match.

Fixes #588

Generated with [Claude Code](https://claude.com/claude-code)
